### PR TITLE
feature/58-add-carendar-components-test

### DIFF
--- a/front/app/src/components/Calendar/__tests__/CalendarBody.test.jsx
+++ b/front/app/src/components/Calendar/__tests__/CalendarBody.test.jsx
@@ -1,0 +1,48 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import CalendarBody from "../CalendarBody";
+
+describe("CalendarBody", () => {
+  const defaultProps = {
+    displayedMonth: new Date(2024, 0, 1),
+    selectedDate: new Date(2024, 0, 1),
+    setSelectedDateExternal: vi.fn(),
+  };
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("曜日が正しく表示される", () => {
+    render(<CalendarBody {...defaultProps} />);
+    const weekdays = ["日", "月", "火", "水", "木", "金", "土"];
+    weekdays.forEach((day) => {
+      expect(screen.getByText(day)).toBeInTheDocument();
+    });
+  });
+
+  test("日付が正しく表示される", () => {
+    render(<CalendarBody {...defaultProps} />);
+    for (let i = 1; i <= 31; i++) {
+      expect(screen.getByText(i.toString())).toBeInTheDocument();
+    }
+  });
+
+  test("日付選択が正しく動作する", () => {
+    render(<CalendarBody {...defaultProps} />);
+    fireEvent.click(screen.getByText("15"));
+    expect(defaultProps.setSelectedDateExternal).toHaveBeenCalled();
+  });
+
+  test("選択された日付のスタイルが正しく適用される", () => {
+    const selectedDate = new Date(2024, 0, 15);
+    render(<CalendarBody {...defaultProps} selectedDate={selectedDate} />);
+
+    // CalendarDay内の要素を探す
+    const selectedDayElement = screen.getByText("15");
+    const dayContainer = selectedDayElement.closest(
+      'div[class*="bg-blue-500"]'
+    );
+    expect(dayContainer).toBeInTheDocument();
+    expect(dayContainer).toHaveClass("bg-blue-500", "text-white");
+  });
+});

--- a/front/app/src/components/Calendar/__tests__/CalendarDay.test.jsx
+++ b/front/app/src/components/Calendar/__tests__/CalendarDay.test.jsx
@@ -1,0 +1,44 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import CalendarDay from "../CalendarDay";
+
+describe("CalendarDay", () => {
+  const defaultProps = {
+    date: new Date(2024, 0, 1), // 2024年1月1日
+    isSelected: false,
+    onClick: vi.fn(),
+  };
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("日付が正しく表示される", () => {
+    render(<CalendarDay {...defaultProps} />);
+    expect(screen.getByText("1")).toBeInTheDocument();
+  });
+
+  test("選択状態のスタイルが正しく適用される", () => {
+    // 非選択状態
+    const { container, rerender } = render(<CalendarDay {...defaultProps} />);
+    const dayElement = container.firstChild;
+    expect(dayElement).toHaveClass("text-gray-700");
+
+    // 選択状態
+    rerender(<CalendarDay {...defaultProps} isSelected={true} />);
+    expect(dayElement).toHaveClass("bg-blue-500");
+    expect(dayElement).toHaveClass("text-white");
+  });
+
+  test("クリックイベントが正しく動作する", () => {
+    render(<CalendarDay {...defaultProps} />);
+    fireEvent.click(screen.getByText("1"));
+    expect(defaultProps.onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test("hover状態のスタイルが適用される", () => {
+    const { container } = render(<CalendarDay {...defaultProps} />);
+    const dayElement = container.firstChild;
+    const classNames = dayElement.className;
+    expect(classNames).toContain("hover:bg-gray-100");
+  });
+});

--- a/front/app/src/components/Calendar/__tests__/CalendarHeader.test.jsx
+++ b/front/app/src/components/Calendar/__tests__/CalendarHeader.test.jsx
@@ -1,0 +1,37 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import CalendarHeader from "../CalendarHeader";
+
+describe("CalendarHeader", () => {
+  const defaultProps = {
+    displayedMonth: new Date(2024, 0, 1), // 2024年1月
+    prevMonth: vi.fn(),
+    nextMonth: vi.fn(),
+  };
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("年月が正しく表示される", () => {
+    render(<CalendarHeader {...defaultProps} />);
+    expect(screen.getByText("2024年 1月")).toBeInTheDocument();
+  });
+
+  test("前月ボタンが正しく動作する", () => {
+    render(<CalendarHeader {...defaultProps} />);
+    fireEvent.click(screen.getByLabelText("前の月"));
+    expect(defaultProps.prevMonth).toHaveBeenCalledTimes(1);
+  });
+
+  test("次月ボタンが正しく動作する", () => {
+    render(<CalendarHeader {...defaultProps} />);
+    fireEvent.click(screen.getByLabelText("次の月"));
+    expect(defaultProps.nextMonth).toHaveBeenCalledTimes(1);
+  });
+
+  test("ボタンのアクセシビリティラベルが正しく設定されている", () => {
+    render(<CalendarHeader {...defaultProps} />);
+    expect(screen.getByLabelText("前の月")).toBeInTheDocument();
+    expect(screen.getByLabelText("次の月")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
# Calendar関連コンポーネントのテスト実装
単体テストの実装
[#58](https://github.com/Kuriyama301/osakana-calendar/issues/58)

## 変更内容
1. CalendarDayコンポーネントのテスト実装
- 日付の表示確認
- 選択状態のスタイル確認（選択時/非選択時）
- クリックイベントの動作確認
- ホバー状態のスタイル確認

2. CalendarHeaderコンポーネントのテスト実装
- 年月の表示確認
- 前月/次月ボタンの動作確認
- アクセシビリティラベルの確認
- アイコンボタンの表示確認

3. CalendarBodyコンポーネントのテスト実装
- 曜日ヘッダーの表示確認
- 月の日数の正確な表示確認
- 日付選択機能の動作確認
- 選択された日付のスタイル確認

## テストの実行方法
docker-compose run --rm frontend-test npm test Calendar