### PR TITLE
feature/58-add-API-tests

### DIFF
--- a/front/app/src/api/__tests__/fish.test.js
+++ b/front/app/src/api/__tests__/fish.test.js
@@ -1,0 +1,92 @@
+import { getFishByDate } from "../fish";
+import { vi, expect } from "vitest";
+
+// スパイを使用してconsole.errorをモック化
+const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+vi.mock("../client", () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+import client from "../client";
+
+describe("getFishByDate", () => {
+  // 各テスト前にスパイをリセット
+  beforeEach(() => {
+    consoleSpy.mockClear();
+  });
+
+  // 各テスト後にモックをリセット
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("日付パラメータがない場合はエラーを投げる", async () => {
+    await expect(getFishByDate()).rejects.toThrow("Date parameter is required");
+  });
+
+  test("正常なレスポンスを処理できる", async () => {
+    const mockFishData = [
+      {
+        id: 1,
+        name: "サンマ",
+        fish_seasons: [
+          {
+            start_month: 9,
+            start_day: 1,
+            end_month: 11,
+            end_day: 30,
+          },
+        ],
+      },
+    ];
+
+    client.get.mockResolvedValueOnce({ data: mockFishData });
+
+    const result = await getFishByDate(new Date("2024-01-01"));
+    expect(result).toEqual(mockFishData);
+    expect(client.get).toHaveBeenCalledWith("api/v1/calendar/fish", {
+      params: { date: "2024-01-01" },
+    });
+  });
+
+  test("404エラーの場合は空配列を返す", async () => {
+    const error = new Error("Not Found");
+    error.response = { status: 404 };
+    client.get.mockRejectedValueOnce(error);
+
+    const result = await getFishByDate(new Date("2024-01-01"));
+    expect(result).toEqual([]);
+  });
+
+  test("APIエラー時は適切なエラーメッセージを表示", async () => {
+    const errorMessage = "API Error";
+    const error = new Error(errorMessage);
+    error.response = {
+      data: { message: errorMessage },
+    };
+    client.get.mockRejectedValueOnce(error);
+
+    await expect(getFishByDate(new Date("2024-01-01"))).rejects.toThrow(
+      errorMessage
+    );
+  });
+
+  test("日付変換が正しく行われる", async () => {
+    client.get.mockResolvedValue({ data: [] });
+
+    // Date オブジェクトでの呼び出し
+    await getFishByDate(new Date("2024-01-01"));
+    expect(client.get).toHaveBeenCalledWith("api/v1/calendar/fish", {
+      params: { date: "2024-01-01" },
+    });
+
+    // 文字列での呼び出し
+    await getFishByDate("2024-01-01");
+    expect(client.get).toHaveBeenCalledWith("api/v1/calendar/fish", {
+      params: { date: "2024-01-01" },
+    });
+  });
+});


### PR DESCRIPTION
# APIクライアントのテスト実装
単体テストの実装
[#58](https://github.com/Kuriyama301/osakana-calendar/issues/58)

## 変更内容
1. APIクライアントのテスト環境構築
- テストディレクトリの作成 (`src/api/__tests__/`)
- Vitestの設定調整
- APIクライアントのモック化

2. getFishByDateのテスト実装
- バリデーションテスト
- 日付パラメータの必須チェック
- 正常系テスト
- レスポンスデータの処理
- APIパラメータの検証
- エラー処理テスト
- 404エラーのハンドリング
- APIエラーメッセージの処理
- 日付形式の変換テスト
- Date オブジェクトの処理
- 文字列形式の日付処理

3. テストユーティリティの整備
- コンソール出力の制御（エラーログの抑制）
- モックデータの準備
- エラーオブジェクトの適切な構築

## テストの実行方法
docker-compose run --rm frontend-test npm test fish.test.js