### PR TITLE
feature/58-add-SeasonalFishModal-test

### DIFF
--- a/front/app/src/components/Fish/__tests__/SeasonalFishModal.test.jsx
+++ b/front/app/src/components/Fish/__tests__/SeasonalFishModal.test.jsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import SeasonalFishModal from "../SeasonalFishModal";
+
+describe("SeasonalFishModal", () => {
+  // デフォルトのprops
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    currentDate: "2024年1月1日",
+    seasonalFish: [],
+    isLoading: false,
+    error: null,
+  };
+
+  // クリーンアップ
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("モーダルが開いているときに日付が表示される", () => {
+    render(<SeasonalFishModal {...defaultProps} />);
+    expect(screen.getByText("2024年1月1日の旬の魚")).toBeInTheDocument();
+  });
+
+  test("魚のリストが表示される", () => {
+    const mockFish = [
+      {
+        id: 1,
+        name: "サンマ",
+        fish_seasons: [
+          {
+            start_month: 9,
+            start_day: 1,
+            end_month: 11,
+            end_day: 30,
+          },
+        ],
+      },
+    ];
+
+    render(<SeasonalFishModal {...defaultProps} seasonalFish={mockFish} />);
+    expect(screen.getByText("サンマ")).toBeInTheDocument();
+  });
+
+  test("データが空の場合適切なメッセージが表示される", () => {
+    render(<SeasonalFishModal {...defaultProps} seasonalFish={[]} />);
+    expect(
+      screen.getByText("この日付の旬の魚はありません。")
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
# SeasonalFishModalコンポーネントの基本機能テスト実装
単体テストの実装
[#58](https://github.com/Kuriyama301/osakana-calendar/issues/58)

## 変更内容
1. SeasonalFishModalの基本機能テスト実装
- 日付表示の確認
  - モーダルタイトルに日付が正しく表示されるか確認
- データ表示機能の確認
  - 魚のリストが正しく表示されるか確認
  - 空データ時の表示メッセージ確認

2. テストユーティリティの整備
```javascript
// テスト用の基本props
const defaultProps = {
  isOpen: true,
  onClose: vi.fn(),
  currentDate: '2024年1月1日',
  seasonalFish: [],
  isLoading: false,
  error: null
};

// テスト用の魚データ
const mockFish = [{
  id: 1,
  name: 'サンマ',
  fish_seasons: [{
    start_month: 9,
    start_day: 1,
    end_month: 11,
    end_day: 30
  }]
}];