### PR TITLE
feature/59-separate-test-functionality

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,8 @@
   },
   "editor.quickSuggestions": {
     "strings": true
+  },
+  "yaml.schemas": {
+    "https://raw.githubusercontent.com/compose-spec/compose-spec/master/schema/compose-spec.json": "docker-compose*.yml"
   }
 }

--- a/api/Dockerfile.dev
+++ b/api/Dockerfile.dev
@@ -14,5 +14,5 @@ RUN bundle install
 
 # アプリケーションコードは volumeでマウント
 
-# 開発サーバー起動
+# 開発サーバー起動のデフォルトコマンド
 CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,19 @@
+echo "Starting tests..."
+
+# 全てのコンテナとネットワークを削除
+docker-compose down --volumes --remove-orphans
+docker-compose -f docker-compose.test.yml down --volumes --remove-orphans
+
+# テストを実行
+docker-compose -f docker-compose.test.yml up --abort-on-container-exit --remove-orphans
+
+# 終了コードを保存
+TEST_EXIT_CODE=$?
+
+# クリーンアップ
+docker-compose -f docker-compose.test.yml down --volumes --remove-orphans
+
+echo "Tests completed."
+
+# テストの終了コードを返す
+exit $TEST_EXIT_CODE

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,39 @@
+services:
+  db-test:
+    image: postgres:14
+    environment:
+      POSTGRES_DB: osakana_calendar_test
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: your_secure_password
+
+  api-test:
+    build:
+      context: ./api
+      dockerfile: Dockerfile.dev
+    volumes:
+      - ./api:/app
+    environment:
+      DATABASE_URL: postgresql://postgres:your_secure_password@db-test:5432/osakana_calendar_test
+      RAILS_ENV: test
+      ALLOWED_ORIGINS: http://localhost:5173
+    depends_on:
+      - db-test
+    command: >
+      bash -c "
+        bundle install &&
+        bundle exec rails db:create db:migrate RAILS_ENV=test &&
+        bundle exec rails test
+      "
+
+  frontend-test:
+    build:
+      context: ./front
+      dockerfile: Dockerfile.dev
+    volumes:
+      - ./front/app:/app
+      - /app/node_modules
+    environment:
+      NODE_ENV: test
+    command: npm test
+    depends_on:
+      - api-test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,35 +22,15 @@ services:
       DATABASE_URL: postgresql://postgres:your_secure_password@db:5432/osakana_calendar_db
       RAILS_ENV: development
       CORS_ORIGINS: http://localhost:5173
+      RAILS_DEVELOPMENT_HOSTS: api,localhost,0.0.0.0
     depends_on:
       - db
     command: >
       bash -c "
-      rm -f tmp/pids/server.pid &&
-      bundle exec rails db:migrate &&
-      bundle exec rails db:seed &&
-      bundle exec rails server -b 0.0.0.0
-      "
-
-  api-test:
-    build:
-      context: ./api
-      dockerfile: Dockerfile.dev
-    volumes:
-      - ./api:/app
-    environment:
-      DATABASE_URL: postgresql://postgres:your_secure_password@db:5432/osakana_calendar_test
-      RAILS_ENV: test
-      CORS_ORIGINS: http://localhost:5173
-    depends_on:
-      - db
-    command: >
-      bash -c "
-      rm -f tmp/pids/server.pid &&
-      bundle exec rails db:migrate RAILS_ENV=test &&
-      bundle exec rails db:seed RAILS_ENV=test &&
-      bundle exec rails test &&
-      bundle exec rails server -b 0.0.0.0
+        rm -f tmp/pids/server.pid &&
+        bundle exec rails db:migrate &&
+        bundle exec rails db:seed &&
+        bundle exec rails server -b 0.0.0.0
       "
 
   frontend:
@@ -67,20 +47,6 @@ services:
       VITE_API_URL: http://localhost:3000
     depends_on:
       - api
-
-  frontend-test:
-    build:
-      context: ./front
-      dockerfile: Dockerfile.dev
-    volumes:
-      - ./front/app:/app
-      - /app/node_modules
-    environment:
-      - NODE_ENV=test
-      - VITE_API_URL=http://api:3000
-    command: npm test
-    depends_on:
-      - api-test
 
 volumes:
   postgres_data:


### PR DESCRIPTION
# docker-compose.test.ymlの追加
統合テストの実装
[#59](https://github.com/Kuriyama301/osakana-calendar/issues/59)
## 変更内容
1. テスト環境の分離
- docker-compose.test.ymlの追加
- docker-compose.ymlに記述されていたテストコマンドなどを移動

2. scriptの追加
- bin/testを追加
- 一連のテストを統一

実行コマンド
./bin/test
```
echo "Starting tests..."

# 全てのコンテナとネットワークを削除
docker-compose down --volumes --remove-orphans
docker-compose -f docker-compose.test.yml down --volumes --remove-orphans

# テストを実行
docker-compose -f docker-compose.test.yml up --abort-on-container-exit --remove-orphans

# 終了コードを保存
TEST_EXIT_CODE=$?

# クリーンアップ
docker-compose -f docker-compose.test.yml down --volumes --remove-orphans

echo "Tests completed."

# テストの終了コードを返す
exit $TEST_EXIT_CODE
```