### PR TITLE
feature/#155-add-search-results-modal

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -37,6 +37,6 @@ services:
       - /app/node_modules
     environment:
       NODE_ENV: test
-    command: npm test
+    command: sh -c "npm run lint && npm test"
     depends_on:
       - api-test

--- a/front/app/src/components/Common/Header.jsx
+++ b/front/app/src/components/Common/Header.jsx
@@ -2,50 +2,67 @@ import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import { Search } from "lucide-react";
 import SearchForm from "../Fish/SearchForm";
-import { searchFish } from "../../api/fish"; // API関数をインポート
+import SearchModal from "../Fish/SearchModal";
+import { searchFish } from "../../api/fish";
 
 function Header() {
   const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const [searchResults, setSearchResults] = useState([]);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
 
   const handleSearch = async (searchTerm) => {
+    setIsLoading(true);
     try {
-      // eslint-disable-next-line no-unused-vars
       const results = await searchFish(searchTerm);
-      // 検索結果を使用して必要な処理を行う
-      // 例: モーダルで表示、特定の要素にスクロールなど
+      setSearchResults(results);
+      setIsModalOpen(true); // 検索結果が取得できたらモーダルを開く
+      setIsSearchOpen(false); // 検索フォームを閉じる
     } catch (error) {
       console.error('Search failed:', error);
-      // エラー処理
+      // エラー処理を追加する場合はここに
+    } finally {
+      setIsLoading(false);
     }
   };
 
   return (
-    <header className="bg-white bg-opacity-85 backdrop-blur-md fixed top-0 left-0 right-0 z-10 shadow-sm">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <nav className="flex justify-between items-center h-16">
-          <Link to="/" className="text-blue-500 text-2xl font-bold flex-shrink-0">
-            オサカナカレンダー
-          </Link>
-          
-          <div className="flex items-center gap-4 flex-grow justify-end max-w-lg">
-            {isSearchOpen ? (
-              <SearchForm 
-                onSearch={handleSearch}
-                className="flex-grow max-w-md"
-              />
-            ) : (
-              <button
-                onClick={() => setIsSearchOpen(true)}
-                className="p-2 hover:bg-gray-100 rounded-full transition-colors"
-                aria-label="検索を開く"
-              >
-                <Search size={20} className="text-gray-500" />
-              </button>
-            )}
-          </div>
-        </nav>
-      </div>
-    </header>
+    <>
+      <header className="bg-white bg-opacity-85 backdrop-blur-md fixed top-0 left-0 right-0 z-10 shadow-sm">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <nav className="flex justify-between items-center h-16">
+            <Link to="/" className="text-blue-500 text-2xl font-bold flex-shrink-0">
+              オサカナカレンダー
+            </Link>
+            
+            <div className="flex items-center gap-4 flex-grow justify-end max-w-lg">
+              {isSearchOpen ? (
+                <SearchForm 
+                  onSearch={handleSearch}
+                  isLoading={isLoading}
+                  className="flex-grow max-w-md"
+                />
+              ) : (
+                <button
+                  onClick={() => setIsSearchOpen(true)}
+                  className="p-2 hover:bg-gray-100 rounded-full transition-colors"
+                  aria-label="検索を開く"
+                >
+                  <Search size={20} className="text-gray-500" />
+                </button>
+              )}
+            </div>
+          </nav>
+        </div>
+      </header>
+
+      {/* 検索モーダルを追加 */}
+      <SearchModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        searchResults={searchResults}
+      />
+    </>
   );
 }
 

--- a/front/app/src/components/Fish/SearchForm.jsx
+++ b/front/app/src/components/Fish/SearchForm.jsx
@@ -39,9 +39,4 @@ SearchForm.propTypes = {
   className: PropTypes.string
 };
 
-SearchForm.defaultProps = {
-  isLoading: false,
-  className: ''
-};
-
 export default SearchForm;

--- a/front/app/src/components/Fish/SearchModal.jsx
+++ b/front/app/src/components/Fish/SearchModal.jsx
@@ -1,0 +1,143 @@
+import React, { useState, useEffect } from "react";
+import PropTypes from "prop-types";
+import { X } from "lucide-react";
+import FishDetails from "./FishDetails";
+import SeasonTerm from "./SeasonTerm";
+
+const SearchModal = ({ isOpen, onClose, searchResults }) => {
+  // 状態管理
+  const [isAnimating, setIsAnimating] = useState(false);
+  const [imageErrors, setImageErrors] = useState({});
+  const [selectedFish, setSelectedFish] = useState(null);
+  const [isFishDetailsOpen, setIsFishDetailsOpen] = useState(false);
+
+  // モーダルの開閉
+  useEffect(() => {
+    if (isOpen) {
+      setIsAnimating(true);
+    } else {
+      const timer = setTimeout(() => setIsAnimating(false), 300);
+      return () => clearTimeout(timer);
+    }
+  }, [isOpen]);
+
+  // 画像読み込みエラー処理
+  const handleImageError = (fishId, fishName) => {
+    setImageErrors((prev) => ({
+      ...prev,
+      [fishId]: true,
+    }));
+    console.log(`Image loading failed for ${fishName}`);
+  };
+
+  // 魚の詳細表示
+  const handleFishClick = (fish) => {
+    // console.log('Fish clicked:', fish); // デバッグ用
+    setSelectedFish(fish);
+    setIsFishDetailsOpen(true);
+  };
+  
+  const handleCloseFishDetails = () => {
+    setIsFishDetailsOpen(false);
+    setSelectedFish(null);
+  };
+
+  // モーダルの非表示時には何もしない
+  if (!isAnimating && !isOpen) return null;
+
+  return (
+    <div
+      className={`fixed inset-0 bg-black flex items-center justify-center z-50 transition-opacity duration-300 ease-in-out ${
+        isAnimating && isOpen ? 'bg-opacity-50' : 'bg-opacity-0'
+      }`}
+      onClick={onClose}
+    >
+      {/* メインのモーダルコンテンツ */}
+      <div
+        className={`bg-white rounded-lg text-gray-800 relative w-full mx-4 sm:mx-8 md:mx-auto md:max-w-2xl 
+          max-h-[90vh] flex flex-col overflow-hidden transform transition-all duration-300 ease-in-out 
+          ${isAnimating && isOpen ? 'scale-100 opacity-100' : 'scale-95 opacity-0'}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* ヘッダー部分 */}
+        <div className="sticky top-0 bg-white z-10 p-4 sm:p-6 border-b border-gray-200">
+          <h2 className="text-xl sm:text-2xl font-bold text-gray-800 pr-8 sm:pr-12">
+            検索結果
+          </h2>
+          <button
+            onClick={onClose}
+            className="absolute top-2 right-2 sm:top-4 sm:right-4 text-gray-600 bg-white hover:bg-gray-300 hover:text-gray-800 rounded-full p-2 transition-colors duration-200"
+          >
+            <X size={24} />
+          </button>
+        </div>
+
+        {/* 検索結果の表示 */}
+        <div className="flex-grow overflow-y-auto scrollbar-hide p-4 sm:p-6">
+          {searchResults.length > 0 ? (
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 sm:gap-6">
+              {searchResults.map((fish) => (
+                <div 
+                  key={fish.id} 
+                  className="flex flex-col items-center justify-center text-center cursor-pointer transition-transform duration-200 hover:scale-105"
+                  onClick={() => handleFishClick(fish)}
+                >
+                  {/* 魚の画像表示 */}
+                  <div className="w-32 h-32 sm:w-40 sm:h-40 flex items-center justify-center mb-2">
+                    {!imageErrors[fish.id] ? (
+                      <img 
+                        src={fish.image_url}
+                        alt={fish.name} 
+                        className="max-w-full max-h-full object-contain rounded-lg"
+                        onError={() => handleImageError(fish.id, fish.name)}
+                      />
+                    ) : (
+                      <div className="w-full h-full bg-gray-200 flex items-center justify-center rounded-lg">
+                        <span className="text-sm text-gray-600">{fish.name}</span>
+                      </div>
+                    )}
+                  </div>
+                  {/* 魚の情報表示 */}
+                  <p className="font-semibold text-gray-800 text-sm sm:text-base">
+                    {fish.name}
+                  </p>
+                  {/* 旬の時期表示 */}
+                  {fish.fish_seasons && fish.fish_seasons.map((season, index) => (
+                    <SeasonTerm key={index} season={season} />
+                  ))}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="text-center py-4">
+              <p className="text-gray-600">該当する魚が見つかりませんでした</p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* 魚の詳細情報モーダル */}
+      <FishDetails
+        isOpen={isFishDetailsOpen}
+        onClose={() => setIsFishDetailsOpen(false)}
+        fish={selectedFish}
+      />
+    </div>
+  );
+};
+
+
+SearchModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  searchResults: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      name: PropTypes.string.isRequired,
+      image_url: PropTypes.string,
+      features: PropTypes.string,
+    })
+  ).isRequired,
+};
+
+export default SearchModal;

--- a/front/app/src/components/Fish/SearchModal.jsx
+++ b/front/app/src/components/Fish/SearchModal.jsx
@@ -36,7 +36,7 @@ const SearchModal = ({ isOpen, onClose, searchResults }) => {
     setSelectedFish(fish);
     setIsFishDetailsOpen(true);
   };
-  
+
   const handleCloseFishDetails = () => {
     setIsFishDetailsOpen(false);
     setSelectedFish(null);
@@ -48,7 +48,7 @@ const SearchModal = ({ isOpen, onClose, searchResults }) => {
   return (
     <div
       className={`fixed inset-0 bg-black flex items-center justify-center z-50 transition-opacity duration-300 ease-in-out ${
-        isAnimating && isOpen ? 'bg-opacity-50' : 'bg-opacity-0'
+        isAnimating && isOpen ? "bg-opacity-50" : "bg-opacity-0"
       }`}
       onClick={onClose}
     >
@@ -56,7 +56,11 @@ const SearchModal = ({ isOpen, onClose, searchResults }) => {
       <div
         className={`bg-white rounded-lg text-gray-800 relative w-full mx-4 sm:mx-8 md:mx-auto md:max-w-2xl 
           max-h-[90vh] flex flex-col overflow-hidden transform transition-all duration-300 ease-in-out 
-          ${isAnimating && isOpen ? 'scale-100 opacity-100' : 'scale-95 opacity-0'}`}
+          ${
+            isAnimating && isOpen
+              ? "scale-100 opacity-100"
+              : "scale-95 opacity-0"
+          }`}
         onClick={(e) => e.stopPropagation()}
       >
         {/* ヘッダー部分 */}
@@ -77,23 +81,25 @@ const SearchModal = ({ isOpen, onClose, searchResults }) => {
           {searchResults.length > 0 ? (
             <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 sm:gap-6">
               {searchResults.map((fish) => (
-                <div 
-                  key={fish.id} 
+                <div
+                  key={fish.id}
                   className="flex flex-col items-center justify-center text-center cursor-pointer transition-transform duration-200 hover:scale-105"
                   onClick={() => handleFishClick(fish)}
                 >
                   {/* 魚の画像表示 */}
                   <div className="w-32 h-32 sm:w-40 sm:h-40 flex items-center justify-center mb-2">
                     {!imageErrors[fish.id] ? (
-                      <img 
+                      <img
                         src={fish.image_url}
-                        alt={fish.name} 
+                        alt={fish.name}
                         className="max-w-full max-h-full object-contain rounded-lg"
                         onError={() => handleImageError(fish.id, fish.name)}
                       />
                     ) : (
                       <div className="w-full h-full bg-gray-200 flex items-center justify-center rounded-lg">
-                        <span className="text-sm text-gray-600">{fish.name}</span>
+                        <span className="text-sm text-gray-600">
+                          {fish.name}
+                        </span>
                       </div>
                     )}
                   </div>
@@ -102,9 +108,10 @@ const SearchModal = ({ isOpen, onClose, searchResults }) => {
                     {fish.name}
                   </p>
                   {/* 旬の時期表示 */}
-                  {fish.fish_seasons && fish.fish_seasons.map((season, index) => (
-                    <SeasonTerm key={index} season={season} />
-                  ))}
+                  {fish.fish_seasons &&
+                    fish.fish_seasons.map((season, index) => (
+                      <SeasonTerm key={index} season={season} />
+                    ))}
                 </div>
               ))}
             </div>
@@ -119,13 +126,12 @@ const SearchModal = ({ isOpen, onClose, searchResults }) => {
       {/* 魚の詳細情報モーダル */}
       <FishDetails
         isOpen={isFishDetailsOpen}
-        onClose={() => setIsFishDetailsOpen(false)}
+        onClose={handleCloseFishDetails}
         fish={selectedFish}
       />
     </div>
   );
 };
-
 
 SearchModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
@@ -136,6 +142,14 @@ SearchModal.propTypes = {
       name: PropTypes.string.isRequired,
       image_url: PropTypes.string,
       features: PropTypes.string,
+      fish_seasons: PropTypes.arrayOf(
+        PropTypes.shape({
+          start_month: PropTypes.number,
+          start_day: PropTypes.number,
+          end_month: PropTypes.number,
+          end_day: PropTypes.number,
+        })
+      ),
     })
   ).isRequired,
 };


### PR DESCRIPTION
# 検索機能の実装（フロントエンド部分）
バックエンドの検索APIと連携し、魚の検索機能とモーダル表示を実装

##検索フォームの作成
[#155](https://github.com/Kuriyama301/osakana-calendar/issues/155)

## 変更内容

1. 検索モーダルの実装
- 検索結果表示用のモーダルコンポーネントを作成
- SeasonalFishModalと同様のスタイルを適用
- 魚の詳細表示機能を追加

2. クリーンアップと状態管理の改善
- モーダルのクリーンアップ処理を追加
- 画像エラー処理の実装
- 条件付きレンダリングの適切な実装

3. 既存コードの改善
- defaultPropsの警告を解消
- コンポーネントの型定義を改善