### PR TITLE
feauture/#185-add-users-model

### DIFF
--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -1,0 +1,13 @@
+class User < ApplicationRecord
+  # 明示的にDeviseをrequire
+  require 'devise'
+
+  # Deviseの機能を追加
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :validatable,
+         :trackable
+
+  # バリデーション設定
+  validates :email, presence: true, uniqueness: true
+  validates :name, presence: true, length: { maximum: 50 }
+end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -1,17 +1,31 @@
 Rails.application.routes.draw do
+  # API用の認証ルーティング設定
+  devise_for :users,
+    path: 'api/v1/auth',  # APIのパス階層に合わせる
+    defaults: { format: :json },  # JSONレスポンスに設定
+    controllers: {
+      sessions: 'api/v1/auth/sessions',
+      registrations: 'api/v1/auth/registrations'
+    }
+
+  # API関連ルーティング
   namespace :api do
     namespace :v1 do
+      # YouTube
       resources :youtube, only: [] do
         collection do
           get 'search'
         end
       end
 
+      # 魚情報関連
       resources :fish, only: [:index, :show] do
         collection do
           get 'search'
         end
       end
+
+      # カレンダー関連
       get '/calendar/fish', to: 'calendar#fish_by_date'
     end
   end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_10_15_092928) do
+ActiveRecord::Schema[7.0].define(version: 2024_11_28_110610) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -62,6 +62,24 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_15_092928) do
     t.datetime "updated_at", null: false
     t.index ["fish_id", "start_month", "start_day", "end_month", "end_day"], name: "index_fish_seasons_on_fish_id_and_dates", unique: true
     t.index ["fish_id"], name: "index_fish_seasons_on_fish_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "name"
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"


### PR DESCRIPTION
## ユーザーモデルとルーティングを設定

# モデルの設定
[#185](https://github.com/Kuriyama301/osakana-calendar/issues/185)

# 変更内容

1. Userモデルの設定
- Deviseを使用したユーザーモデルを追加
- 認証用ルーティングを設定

2. バリデーションの追加
- メールアドレス及び名前のバリデーション