### PR TITLE
feature/#213-add-email-authentication

### DIFF
--- a/api/config/environments/production.rb
+++ b/api/config/environments/production.rb
@@ -27,6 +27,27 @@ Rails.application.configure do
   Rails.application.routes.default_url_options = routes_config
   config.action_controller.default_url_options = routes_config
 
+  # メール設定
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.perform_caching = false
+  config.action_mailer.default_url_options = {
+    host: host,
+    protocol: 'https'
+  }
+
+  # Gmail SMTP設定
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: 'smtp.gmail.com',
+    port: 587,
+    domain: host,
+    user_name: ENV['GMAIL_USERNAME'],
+    password: ENV['GMAIL_APP_PASSWORD'],
+    authentication: :plain,
+    enable_starttls_auto: true
+  }
+
   # セキュリティ設定
   config.force_ssl = true
 end


### PR DESCRIPTION
## メール認証機能の実装

# パスワードリセット機能の追加
[#213](https://github.com/Kuriyama301/osakana-calendar/issues/213)

# 変更内容

1. メール送信機能の基盤実装
- ApplicationMailerの設定
- 開発環境用のメール設定（test mode）
- メールテンプレートの実装
  - confirmation_instructions.html.erb
  - reset_password_instructions.html.erb
  - メールレイアウトの実装（mailer.html.erb, mailer.text.erb）

2. メール認証用コントローラーの実装
- API::V1::Auth::ConfirmationsControllerの実装
  - メールアドレス確認処理
  - 確認メール再送信機能
  - JSONレスポンス形式での処理
- API::V1::Auth::PasswordsControllerの実装
  - パスワードリセットメール送信
  - エラーハンドリング

3. 認証メール用のビューテンプレート実装
- アカウント確認用メールテンプレート
- パスワードリセット用メールテンプレート
- 共通レイアウトの実装