### PR TITLE
feature/#213-add-SMTP-settings

### DIFF
--- a/api/app/mailers/application_mailer.rb
+++ b/api/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: ENV.fetch('MAILER_FROM', 'no-reply@example.com')
+  default from: ENV.fetch('MAILER_FROM', 'info@osakana-calendar.com')
   layout 'mailer'
 end

--- a/api/config/environments/production.rb
+++ b/api/config/environments/production.rb
@@ -27,27 +27,26 @@ Rails.application.configure do
   Rails.application.routes.default_url_options = routes_config
   config.action_controller.default_url_options = routes_config
 
-  # メール設定
+  # セキュリティ設定
+  config.force_ssl = true
+
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_caching = false
   config.action_mailer.default_url_options = {
-    host: host,
+    host: 'www.osakana-calendar.com',
     protocol: 'https'
   }
 
-  # Gmail SMTP設定
+  # お名前.comのSMTP設定
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    address: 'smtp.gmail.com',
-    port: 587,
-    domain: host,
-    user_name: ENV['GMAIL_USERNAME'],
-    password: ENV['GMAIL_APP_PASSWORD'],
+    address: ENV['SMTP_ADDRESS'],        # お名前.comのSMTPサーバーアドレス
+    port: 587,                          # SMTP用ポート
+    domain: 'osakana-calendar.com',     # あなたのドメイン
+    user_name: ENV['SMTP_USERNAME'],    # お名前.comで設定したメールアドレス
+    password: ENV['SMTP_PASSWORD'],     # お名前.comで設定したパスワード
     authentication: :plain,
     enable_starttls_auto: true
   }
-
-  # セキュリティ設定
-  config.force_ssl = true
 end


### PR DESCRIPTION
# お名前.comメールサービスを使用したメール配信設定の実装

## 関連Issue
#213 パスワードリセット機能の追加

## 変更内容

1. メール配信基盤の設定
- お名前.comのSMTPサーバーを使用するための設定実装
- config/environments/production.rbのメール設定
- 環境変数の設定
- STARTTLSによるセキュアな通信設定を追加

2. ApplicationMailerの設定修正
- 送信元メールアドレスの設定
- メールレイアウトの設定
- 環境変数を使用した設定値の管理

3. 環境別の設定実装
(本番)
- お名前.comのSMTPサーバーを使用
- 環境変数による認証情報の管理
- SSLによるセキュアな通信設定

(開発)
- テストモードでのメール送信設定
- ローカル環境での動作確認用設定