### PR TITLE
feature/#189-add-auth-components

### DIFF
--- a/front/app/package.json
+++ b/front/app/package.json
@@ -17,7 +17,8 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "test:ui": "vitest --ui"
+    "test:ui": "vitest --ui",
+    "js-cookie": "^3.0.5"
   },
   "dependencies": {
     "axios": "^1.6.2",

--- a/front/app/src/App.jsx
+++ b/front/app/src/App.jsx
@@ -4,6 +4,7 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import HomePage from "./pages/HomePage";
 import { CalendarProvider } from "./CalendarContext.jsx";
 import LoadingScreen from "./components/Common/LoadingScreen.jsx";
+import { AuthProvider } from "./contexts/AuthContext";
 
 class ErrorBoundary extends Component {
   constructor(props) {
@@ -26,7 +27,9 @@ class ErrorBoundary extends Component {
       return (
         <div className="flex items-center justify-center h-screen bg-gray-50">
           <div className="text-center p-4">
-            <p className="text-lg text-gray-700">予期せぬエラーが発生しました</p>
+            <p className="text-lg text-gray-700">
+              予期せぬエラーが発生しました
+            </p>
             <button
               onClick={() => window.location.reload()}
               className="mt-4 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
@@ -69,20 +72,22 @@ function App() {
 
   return (
     <ErrorBoundary>
-      <CalendarProvider>
-        <Router>
-          <div className="h-screen overflow-hidden">
-            <LoadingScreen isOpen={isInitialLoading} />
-            <Suspense fallback={<LoadingScreen isOpen={true} />}>
-              <main className="h-full">
-                <Routes>
-                  <Route path="/" element={<HomePage />} />
-                </Routes>
-              </main>
-            </Suspense>
-          </div>
-        </Router>
-      </CalendarProvider>
+      <AuthProvider>
+        <CalendarProvider>
+          <Router>
+            <div className="h-screen overflow-hidden">
+              <LoadingScreen isOpen={isInitialLoading} />
+              <Suspense fallback={<LoadingScreen isOpen={true} />}>
+                <main className="h-full">
+                  <Routes>
+                    <Route path="/" element={<HomePage />} />
+                  </Routes>
+                </main>
+              </Suspense>
+            </div>
+          </Router>
+        </CalendarProvider>
+      </AuthProvider>
     </ErrorBoundary>
   );
 }

--- a/front/app/src/api/auth.js
+++ b/front/app/src/api/auth.js
@@ -1,0 +1,70 @@
+import client from "./client";
+
+// レスポンスエラーを整形するヘルパー関数
+const formatError = (error) => {
+  if (error.response?.data?.errors) {
+    return Object.values(error.response.data.errors).flat().join(", ");
+  }
+  if (error.response?.data?.error) {
+    return error.response.data.error;
+  }
+  return "エラーが発生しました。しばらく経ってからお試しください。";
+};
+
+export const authAPI = {
+  // ログイン
+  login: async (email, password) => {
+    try {
+      const response = await client.post("/api/v1/auth/sign_in", {
+        user: { email, password },
+      });
+
+      // JWTトークンをレスポンスヘッダーから取得
+      const authToken = response.headers["authorization"];
+      if (authToken) {
+        // クライアントのデフォルトヘッダーにトークンを設定
+        client.defaults.headers.common["Authorization"] = authToken;
+      }
+
+      return {
+        user: response.data,
+        token: authToken,
+      };
+    } catch (error) {
+      throw formatError(error);
+    }
+  },
+
+  // サインアップ
+  signup: async (email, password, passwordConfirmation) => {
+    try {
+      const response = await client.post("/api/v1/auth/sign_up", {
+        user: {
+          email,
+          password,
+          password_confirmation: passwordConfirmation,
+        },
+      });
+
+      return {
+        user: response.data,
+        message: "アカウントを作成しました。確認メールをご確認ください。",
+      };
+    } catch (error) {
+      throw formatError(error);
+    }
+  },
+
+  // ログアウト
+  logout: async () => {
+    try {
+      await client.delete("/api/v1/auth/sign_out");
+      // ヘッダーからトークンを削除
+      delete client.defaults.headers.common["Authorization"];
+    } catch (error) {
+      throw formatError(error);
+    }
+  },
+};
+
+export default authAPI;

--- a/front/app/src/contexts/AuthContext.jsx
+++ b/front/app/src/contexts/AuthContext.jsx
@@ -1,0 +1,119 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+} from "react";
+import PropTypes from "prop-types";
+import { authAPI } from "../api/auth";
+import client from "../api/client";
+import Cookies from "js-cookie";
+
+// トークン用のCookie名を定数化（定数は別ファイルに移動することも検討可能）
+const TOKEN_COOKIE_KEY = "auth_token";
+
+// コンテキストの作成
+const AuthContext = createContext(null);
+
+// プロバイダーコンポーネント
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  // 初期認証状態の確認
+  useEffect(() => {
+    const checkAuthStatus = async () => {
+      try {
+        const token = Cookies.get(TOKEN_COOKIE_KEY);
+        if (token) {
+          // TODO: トークンの有効性検証やユーザー情報の取得
+          // 現時点では簡易的な実装
+          client.defaults.headers.common["Authorization"] = token;
+        }
+      } catch (err) {
+        console.error("Authentication check failed:", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    checkAuthStatus();
+  }, []);
+
+  // ログイン処理
+  const login = useCallback(async (email, password) => {
+    try {
+      setError(null);
+      const { user, token } = await authAPI.login(email, password);
+      setUser(user);
+      Cookies.set(TOKEN_COOKIE_KEY, token, { secure: true });
+      return user;
+    } catch (err) {
+      setError(err);
+      throw err;
+    }
+  }, []);
+
+  // サインアップ処理
+  const signup = useCallback(async (email, password, passwordConfirmation) => {
+    try {
+      setError(null);
+      const result = await authAPI.signup(
+        email,
+        password,
+        passwordConfirmation
+      );
+      return result;
+    } catch (err) {
+      setError(err);
+      throw err;
+    }
+  }, []);
+
+  // ログアウト処理
+  const logout = useCallback(async () => {
+    try {
+      await authAPI.logout();
+      setUser(null);
+      Cookies.remove(TOKEN_COOKIE_KEY);
+    } catch (err) {
+      setError(err);
+      throw err;
+    }
+  }, []);
+
+  // 認証状態チェック
+  const isAuthenticated = useCallback(() => {
+    return !!user && !!Cookies.get(TOKEN_COOKIE_KEY);
+  }, [user]);
+
+  const value = {
+    user,
+    loading,
+    error,
+    login,
+    signup,
+    logout,
+    isAuthenticated,
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+// PropTypesの定義
+AuthProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+// useAuthフック
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return context;
+};
+
+export default AuthContext;


### PR DESCRIPTION
# 認証関連の基盤実装

## 関連Issue
認証関連コンポーネント作成
[#189](https://github.com/Kuriyama301/osakana-calendar/issues/189)

## 変更内容

1. 認証用APIクライアントの実装
- auth.jsの作成によるAPI通信の集約
- ログイン、サインアップ、ログアウト機能の実装
- エラーハンドリングの統一化
- JWTトークン管理の実装

2. 認証状態管理の実装
- AuthContext.jsxによるグローバルな認証状態管理
- ユーザー情報の状態管理
- トークンのCookie管理
- 認証状態チェック機能

3. アプリケーション構造の更新
- App.jsxへのAuthProviderの統合
- 既存のプロバイダー構造の維持