### PR TITLE
feature/#237-AWS-SES-setting

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -25,7 +25,10 @@ gem 'mutex_m'
 
 # Active Storage関連
 gem 'active_storage_validations'
+
+# AWS関連
 gem 'aws-sdk-s3', require: false # S3用
+gem 'aws-sdk-ses'               # Amazon SES用
 
 gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw ]
 

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -85,6 +85,9 @@ GEM
       aws-sdk-core (~> 3, >= 3.210.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
+    aws-sdk-ses (1.78.0)
+      aws-sdk-core (~> 3, >= 3.210.0)
+      aws-sigv4 (~> 1.5)
     aws-sigv4 (1.10.1)
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
@@ -297,6 +300,7 @@ PLATFORMS
 DEPENDENCIES
   active_storage_validations
   aws-sdk-s3
+  aws-sdk-ses
   base64
   bigdecimal
   bootsnap

--- a/api/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/api/app/controllers/api/v1/auth/registrations_controller.rb
@@ -3,25 +3,56 @@ module Api
     module Auth
       class RegistrationsController < Devise::RegistrationsController
         respond_to :json
+        before_action :configure_sign_up_params, only: [:create]
 
         private
 
-        def respond_with(resource, _opts = {})
-          if resource.persisted?
-            render json: {
-              message: 'ユーザー登録が完了しました',
-              user: resource
-            }, status: :created
-          else
-            render json: {
-              message: '登録に失敗しました',
-              errors: resource.errors.full_messages
-            }, status: :unprocessable_entity
-          end
+        def configure_sign_up_params
+          devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
         end
 
         def sign_up_params
           params.require(:user).permit(:email, :password, :password_confirmation, :name)
+        end
+
+        def respond_with(resource, _opts = {})
+          if resource.persisted?
+            render json: {
+              status: 'success',
+              message: '登録確認メールを送信しました',
+              data: UserSerializer.new(resource).serializable_hash
+            }, status: :created
+          else
+            render json: {
+              status: 'error',
+              message: '登録に失敗しました',
+              errors: format_error_messages(resource.errors)
+            }, status: :unprocessable_entity
+          end
+        end
+
+        protected
+
+        def format_error_messages(errors)
+          errors.full_messages.map do |message|
+            {
+              detail: message,
+              source: get_error_source(message)
+            }
+          end
+        end
+
+        def get_error_source(message)
+          case message
+          when /Email/i
+            'email'
+          when /Password/i
+            'password'
+          when /Name/i
+            'name'
+          else
+            'other'
+          end
         end
       end
     end

--- a/api/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/api/app/controllers/api/v1/auth/sessions_controller.rb
@@ -2,23 +2,52 @@ module Api
   module V1
     module Auth
       class SessionsController < Devise::SessionsController
+        include ActionController::Cookies
         respond_to :json
+        skip_before_action :verify_signed_out_user, only: [:destroy]
+
+        def create
+          self.resource = warden.authenticate!(auth_options)
+          sign_in(resource_name, resource)
+          respond_with(resource)
+        end
 
         private
 
-        def respond_to_on_authenticate
-          self.resource = warden.authenticate!(auth_options)
-          sign_in(resource_name, resource)
-          render json: {
-            message: 'ログインしました',
-            user: UserSerializer.new(current_user).serializable_hash
-          }, status: :ok
+        def respond_with(resource, _opts = {})
+          if resource.persisted? && resource.confirmed?
+            render json: {
+              status: 'success',
+              message: 'ログインしました',
+              data: UserSerializer.new(resource).serializable_hash,
+              token: request.env['warden-jwt_auth.token']
+            }, status: :ok
+          else
+            render json: {
+              status: 'error',
+              message: resource.confirmed? ? 'メールアドレスまたはパスワードが正しくありません' : 'メールアドレスの確認が必要です'
+            }, status: :unauthorized
+          end
         end
 
-        def respond_to_on_authentication_failure
-          render json: {
-            error: 'メールアドレスまたはパスワードが正しくありません'
-          }, status: :unauthorized
+        def respond_to_on_destroy
+          if current_user
+            render json: {
+              status: 'success',
+              message: 'ログアウトしました'
+            }, status: :ok
+          else
+            render json: {
+              status: 'error',
+              message: '認証エラーが発生しました'
+            }, status: :unauthorized
+          end
+        end
+
+        protected
+
+        def auth_options
+          { scope: resource_name, recall: "#{controller_path}#new" }
         end
       end
     end

--- a/api/app/controllers/application_controller.rb
+++ b/api/app/controllers/application_controller.rb
@@ -1,11 +1,30 @@
 class ApplicationController < ActionController::API
   include ActionController::MimeResponds
+  include ActionController::HttpAuthentication::Token::ControllerMethods
   respond_to :json
+
+  before_action :configure_permitted_parameters, if: :devise_controller?
 
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :email, :password, :password_confirmation])
     devise_parameter_sanitizer.permit(:account_update, keys: [:name])
+  end
+
+  def authenticate_user!
+    if request.headers['Authorization'].present?
+      jwt_payload = JWT.decode(request.headers['Authorization'].split(' ').last,
+                             Rails.application.credentials.secret_key_base).first
+      @current_user_id = jwt_payload['sub']
+    else
+      render json: { error: 'Not Authorized' }, status: :unauthorized
+    end
+  rescue JWT::ExpiredSignature, JWT::VerificationError, JWT::DecodeError
+    render json: { error: 'Not Authorized' }, status: :unauthorized
+  end
+
+  def current_user
+    @current_user ||= super || User.find(@current_user_id)
   end
 end

--- a/api/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/api/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -2,4 +2,4 @@
 
 <p>以下のリンクをクリックして、メールアドレスの確認を完了してください：</p>
 
-<p><%= link_to 'メールアドレスを確認する', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p><%= link_to 'メールアドレスを確認する', user_confirmation_url(confirmation_token: @token) %></p>

--- a/api/config/environments/development.rb
+++ b/api/config/environments/development.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
   config.active_record.verbose_query_logs = true
 
   # ホスト許可設定
-  config.hosts = nil # 開発環境ではホストチェックを無効化
+  config.hosts = nil
 
   # URL・メール設定
   host = ENV.fetch('MAILER_HOST', 'localhost')
@@ -44,13 +44,22 @@ Rails.application.configure do
   }
 
   # メール設定
+  config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.perform_caching = false
-  config.action_mailer.delivery_method = :test
   config.action_mailer.default_url_options = {
-    host: host,
-    port: port,
+    host: ENV.fetch('MAILER_HOST', 'localhost'),
+    port: ENV.fetch('MAILER_PORT', 3000),
     protocol: 'http'
+  }
+
+  config.action_mailer.smtp_settings = {
+    address: 'email-smtp.ap-northeast-1.amazonaws.com',
+    port: 587,
+    user_name: ENV.fetch('AWS_SES_SMTP_USER'),
+    password: ENV.fetch('AWS_SES_SMTP_PASSWORD'),
+    authentication: :login,
+    enable_starttls_auto: true,
+    domain: 'osakana-calendar.com'
   }
 end

--- a/api/config/environments/production.rb
+++ b/api/config/environments/production.rb
@@ -46,17 +46,20 @@ Rails.application.configure do
     from: ENV.fetch('MAILER_FROM', 'info@osakana-calendar.com')
   }
 
-  # SMTP設定
+  # メール設定セクションを更新
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    address: ENV.fetch('SMTP_ADDRESS', 'mail1026.onamae.ne.jp'),
-    port: ENV.fetch('SMTP_PORT', 587).to_i,
-    domain: ENV.fetch('SMTP_DOMAIN', 'osakana-calendar.com'),
-    user_name: ENV.fetch('SMTP_USERNAME', 'info@osakana-calendar.com'),
-    password: ENV.fetch('SMTP_PASSWORD'),
+    address: 'email-smtp.ap-northeast-1.amazonaws.com',
+    port: 587,
+    user_name: ENV.fetch('AWS_SES_SMTP_USER'),
+    password: ENV.fetch('AWS_SES_SMTP_PASSWORD'),
     authentication: :login,
     enable_starttls_auto: true,
-    open_timeout: 5,
-    read_timeout: 5
+    domain: 'osakana-calendar.com'
+  }
+
+  config.action_mailer.default_url_options = {
+    host: ENV.fetch('HOST', 'www.osakana-calendar.com'),
+    protocol: 'https'
   }
 end

--- a/api/config/initializers/devise.rb
+++ b/api/config/initializers/devise.rb
@@ -3,8 +3,11 @@ require 'devise/jwt'
 require 'devise/orm/active_record'
 
 Devise.setup do |config|
-  config.navigational_formats = [] # APIモードの設定
-  config.mailer_sender = 'no-reply@example.com'
+  # API設定
+  config.navigational_formats = []
+
+  # メール送信者の設定
+  config.mailer_sender = ENV.fetch('MAILER_FROM', 'no-reply@example.com')
 
   # 基本設定
   config.case_insensitive_keys = [:email]
@@ -14,14 +17,16 @@ Devise.setup do |config|
   config.password_length = 6..128
   config.reset_password_within = 6.hours
 
-  # メール設定
-  config.mailer_sender = ENV.fetch('MAILER_FROM', 'no-reply@example.com')
+  # メール確認の設定
+  config.reconfirmable = true
+  config.confirm_within = 24.hours
+  config.allow_unconfirmed_access_for = 0.days
+
+  # 親メーラー設定
   config.parent_mailer = 'ActionMailer::Base'
 
   # セキュリティ設定
   config.stretches = Rails.env.test? ? 1 : 12
-  config.reconfirmable = true                    # メールアドレス変更時の再確認
-  config.confirm_within = 3.days                 # メール確認の期限
   config.expire_all_remember_me_on_sign_out = true
   config.sign_out_via = :delete
   config.skip_session_storage = [:http_auth]
@@ -33,4 +38,11 @@ Devise.setup do |config|
     jwt.revocation_requests = [['DELETE', %r{^/api/v1/auth/sign_out$}]]
     jwt.expiration_time = 24.hours.to_i
   end
+
+  # その他のDevise設定
+  config.authentication_keys = [:email]
+  config.reset_password_within = 6.hours
+  config.sign_in_after_reset_password = true
+  config.remember_for = 2.weeks
+  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
-  namespace :api do
-    namespace :v1 do
+  # API用のルーティング
+  scope :api do
+    scope :v1 do
       # Devise認証ルーティング
       devise_for :users,
         path: 'auth',
@@ -11,7 +12,12 @@ Rails.application.routes.draw do
           passwords: 'api/v1/auth/passwords',
           confirmations: 'api/v1/auth/confirmations'
         }
+    end
+  end
 
+  # API機能用のルーティング
+  namespace :api do
+    namespace :v1 do
       # YouTube検索
       get 'youtube/search', to: 'youtube#search'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,5 +58,4 @@ services:
 
 volumes:
   postgres_data:
-
 # docker-compose --env-file .env.development up --build


### PR DESCRIPTION
# AWS SESの導入による環境構築

## 関連Issue
 AWS SES
[#237](https://github.com/Kuriyama301/osakana-calendar/issues/237)

## 変更内容
1. AWS SES設定の実装
- IAMユーザーの作成とSES権限の付与
- DNSレコードの設定（DKIM、DMARC）
- SMTP認証情報の生成と設定
- サンドボックス環境での初期設定完了

2. アプリケーション設定の更新
- 開発環境のメール設定をAWS SESに移行
- 本番環境のメール設定の更新
- 環境変数の整理と更新
- SMTP設定の最適化