### PR TITLE
feature/#249-add-token-manage

### DIFF
--- a/api/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/api/app/controllers/api/v1/auth/sessions_controller.rb
@@ -8,12 +8,11 @@ module Api
         def create
           Rails.logger.info "ログイン試行パラメータ: #{params.inspect}"
 
-          self.resource = warden.authenticate!(auth_options)
+          self.resource = warden.authenticate(auth_options)
 
-          if resource && resource.confirmed?
+          if resource&.confirmed?
             sign_in(resource_name, resource)
             token = generate_jwt_token(resource)
-            Rails.logger.info "生成されたトークン: #{token}"
 
             render json: {
               status: 'success',
@@ -25,6 +24,60 @@ module Api
             render json: {
               status: 'error',
               message: 'ログインに失敗しました'
+            }, status: :unauthorized
+          end
+        end
+
+        def destroy
+          token = request.headers['Authorization']&.split(' ')&.last
+
+          if token.present?
+            begin
+              jwt_payload = decode_jwt_token(token)
+              user = User.find_by(id: jwt_payload['sub'])
+
+              if user
+                # JWTトークンをブラックリストに追加
+                JwtDenylist.find_or_create_by!(jti: jwt_payload['jti']) do |record|
+                  record.exp = Time.at(jwt_payload['exp'])
+                end
+
+                # Deviseのログアウト処理
+                sign_out(user)
+
+                render json: {
+                  status: 'success',
+                  message: 'ログアウトしました'
+                }, status: :ok
+              else
+                render json: {
+                  status: 'error',
+                  message: 'ユーザーが見つかりません'
+                }, status: :not_found
+              end
+            rescue JWT::DecodeError => e
+              Rails.logger.error "JWT decode error: #{e.message}"
+              render json: {
+                status: 'error',
+                message: e.message
+              }, status: :unauthorized
+            rescue ActiveRecord::RecordNotUnique
+              # トークンが既にブラックリストに存在する場合
+              render json: {
+                status: 'success',
+                message: 'ログアウトしました'
+              }, status: :ok
+            rescue StandardError => e
+              Rails.logger.error "Unexpected error: #{e.message}"
+              render json: {
+                status: 'error',
+                message: 'ログアウト処理中にエラーが発生しました'
+              }, status: :internal_server_error
+            end
+          else
+            render json: {
+              status: 'error',
+              message: 'トークンが提供されていません'
             }, status: :unauthorized
           end
         end
@@ -42,6 +95,14 @@ module Api
             ENV['DEVISE_JWT_SECRET_KEY'],
             'HS256'
           )
+        end
+
+        def decode_jwt_token(token)
+          JWT.decode(token, ENV['DEVISE_JWT_SECRET_KEY'], true, algorithm: 'HS256').first
+        rescue JWT::ExpiredSignature
+          raise JWT::DecodeError, 'トークンが期限切れです'
+        rescue JWT::DecodeError
+          raise JWT::DecodeError, '無効なトークンです'
         end
       end
     end

--- a/front/app/src/contexts/AuthContext.jsx
+++ b/front/app/src/contexts/AuthContext.jsx
@@ -8,10 +8,11 @@ import {
 import PropTypes from "prop-types";
 import { authAPI } from "../api/auth";
 import client from "../api/client";
-import { tokenManager } from "../utils/tokenManager"; // tokenManager をインポート
+import { tokenManager } from "../utils/tokenManager";
+import { formatError } from "../utils/errorHandler";
 
-// トークン用のCookie名を定数化（定数は別ファイルに移動することも検討）
-const TOKEN_COOKIE_KEY = "auth_token";
+// トークン用のCookie名を定数化
+// const TOKEN_COOKIE_KEY = "auth_token";
 
 // コンテキストの作成
 const AuthContext = createContext(null);

--- a/front/app/src/contexts/AuthContext.jsx
+++ b/front/app/src/contexts/AuthContext.jsx
@@ -8,9 +8,9 @@ import {
 import PropTypes from "prop-types";
 import { authAPI } from "../api/auth";
 import client from "../api/client";
-import Cookies from "js-cookie";
+import { tokenManager } from "../utils/tokenManager"; // tokenManager をインポート
 
-// トークン用のCookie名を定数化（定数は別ファイルに移動することも検討可能）
+// トークン用のCookie名を定数化（定数は別ファイルに移動することも検討）
 const TOKEN_COOKIE_KEY = "auth_token";
 
 // コンテキストの作成
@@ -22,76 +22,65 @@ export const AuthProvider = ({ children }) => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  // 初期認証状態の確認
+  // 初期化時の処理を改善
   useEffect(() => {
-    const checkAuthStatus = async () => {
+    const initializeAuth = async () => {
       try {
-        const token = Cookies.get(TOKEN_COOKIE_KEY);
-        if (token) {
+        setLoading(true);
+        const token = tokenManager.getToken();
+        const userData = tokenManager.getUser();
+
+        if (token && userData) {
+          // トークンの検証
           client.defaults.headers.common["Authorization"] = `Bearer ${token}`;
+          setUser(userData);
+        } else {
+          tokenManager.clearAll();
         }
       } catch (err) {
-        console.error("Authentication check failed:", err);
+        console.error("Auth initialization error:", err);
+        tokenManager.clearAll();
       } finally {
         setLoading(false);
       }
     };
 
-    checkAuthStatus();
+    initializeAuth();
   }, []);
 
-  // ログイン処理
+  // ログイン処理の改善
   const login = useCallback(async (email, password) => {
     try {
       setError(null);
       const { user, token } = await authAPI.login(email, password);
+
+      tokenManager.setToken(token);
+      tokenManager.setUser(user);
       setUser(user);
-      Cookies.set(TOKEN_COOKIE_KEY, `Bearer ${token}`, {
-        secure: true,
-        sameSite: "Strict",
-      });
+
       return user;
     } catch (err) {
-      setError(err);
+      setError(formatError(err));
       throw err;
     }
   }, []);
 
-  const signup = useCallback(
-    async (email, password, passwordConfirmation, name) => {
-      try {
-        setError(null);
-        const response = await authAPI.signup(
-          email,
-          password,
-          passwordConfirmation,
-          name
-        );
-        return response;
-      } catch (err) {
-        setError(err);
-        throw err;
-      }
-    },
-    []
-  );
-
-  // ログアウト処理
+  // ログアウト処理の改善
   const logout = useCallback(async () => {
     try {
       await authAPI.logout();
-      setUser(null);
-      Cookies.remove(TOKEN_COOKIE_KEY);
-      delete client.defaults.headers.common["Authorization"];
     } catch (err) {
-      setError(err);
-      throw err;
+      console.error("Logout error:", err);
+    } finally {
+      setUser(null);
+      tokenManager.clearAll();
+      delete client.defaults.headers.common["Authorization"];
     }
   }, []);
 
   // 認証状態チェック
   const isAuthenticated = useCallback(() => {
-    return !!user && !!Cookies.get(TOKEN_COOKIE_KEY);
+    return !!user && !!tokenManager.getToken(); // tokenManager でトークン存在確認
   }, [user]);
 
   const value = {
@@ -99,7 +88,6 @@ export const AuthProvider = ({ children }) => {
     loading,
     error,
     login,
-    signup,
     logout,
     isAuthenticated,
   };

--- a/front/app/src/utils/errorHandler.js
+++ b/front/app/src/utils/errorHandler.js
@@ -1,0 +1,42 @@
+export const formatError = (error) => {
+  if (!error) {
+    return "予期せぬエラーが発生しました";
+  }
+
+  // APIエラーの場合
+  if (error.response?.data) {
+    const { data } = error.response;
+
+    // 構造化されたエラーメッセージ
+    if (data.errors && Array.isArray(data.errors)) {
+      return data.errors.join(", ");
+    }
+
+    // 単一のエラーメッセージ
+    if (data.message || data.error) {
+      return data.message || data.error;
+    }
+  }
+
+  // ネットワークエラー
+  if (error.message === "Network Error") {
+    return "サーバーに接続できません。インターネット接続を確認してください。";
+  }
+
+  // その他のエラー
+  return error.message || "予期せぬエラーが発生しました";
+};
+
+export const handleAuthError = (error) => {
+  // 認証エラー
+  if (error.response?.status === 401) {
+    return "メールアドレスまたはパスワードが正しくありません";
+  }
+
+  // アカウント未確認
+  if (error.response?.status === 403) {
+    return "メールアドレスの確認が必要です";
+  }
+
+  return formatError(error);
+};

--- a/front/app/src/utils/tokenManager.js
+++ b/front/app/src/utils/tokenManager.js
@@ -1,0 +1,61 @@
+import Cookies from "js-cookie";
+
+const TOKEN_COOKIE_KEY = "auth_token";
+const USER_COOKIE_KEY = "user_data";
+
+export const tokenManager = {
+  // トークンの保存（有効期限を設定）
+  setToken(token) {
+    if (token) {
+      // セキュアなCookie設定
+      Cookies.set(TOKEN_COOKIE_KEY, token, {
+        secure: true,
+        sameSite: "Strict",
+        expires: 1, // 1日
+        path: "/",
+      });
+    }
+  },
+
+  // ユーザー情報の保存
+  setUser(user) {
+    if (user) {
+      Cookies.set(USER_COOKIE_KEY, JSON.stringify(user), {
+        secure: true,
+        sameSite: "Strict",
+        expires: 1,
+        path: "/",
+      });
+    }
+  },
+
+  // トークンの取得
+  getToken() {
+    return Cookies.get(TOKEN_COOKIE_KEY);
+  },
+
+  // ユーザー情報の取得
+  getUser() {
+    const userData = Cookies.get(USER_COOKIE_KEY);
+    return userData ? JSON.parse(userData) : null;
+  },
+
+  // 全てのデータを削除
+  clearAll() {
+    Cookies.remove(TOKEN_COOKIE_KEY, { path: "/" });
+    Cookies.remove(USER_COOKIE_KEY, { path: "/" });
+  },
+
+  // 認証状態の確認
+  isAuthenticated() {
+    return !!this.getToken() && !!this.getUser();
+  },
+
+  // Authorization ヘッダーの形式でトークンを取得
+  getAuthHeader() {
+    const token = this.getToken();
+    return token ? `Bearer ${token}` : null;
+  }
+};
+
+export default tokenManager;


### PR DESCRIPTION
# ログイン・ログアウト機能の実装

## 関連Issue
ログイン状態の管理
[#249](https://github.com/Kuriyama301/osakana-calendar/issues/249)

## 変更内容

1. バックエンド実装（API）
- ログイン・ログアウト機能の実装
  - Sessions Controllerの実装
  - JWTトークン認証の統合
  - トークン無効化機能の実装
- JWTDenylistの実装
  - トークンのブラックリスト管理
  - 有効期限管理の実装

2. フロントエンド実装
- トークン管理の改善
  - Cookie basedのトークン管理実装
  - セキュアな属性設定の追加
- 認証状態の永続化対応
  - AuthContextの実装改善
  - トークンマネージャーの実装
- エラーハンドリングの改善
  - エラーメッセージの統一
  - ユーザーフレンドリーなエラー表示

3. セキュリティ強化
- Cookie属性の適切な設定
  - Secure属性の追加
  - SameSite設定の追加
- トークン管理の改善
  - JWT無効化の実装
  - セッション管理の強化

## 動作確認済み
```bash
# ログイン
curl -X POST http://localhost:3000/api/v1/auth/sign_in \
-H "Content-Type: application/json" \
-d '{"user": {"email": "test@example.com", "password": "password123"}}'

# ログアウト
curl -X DELETE "http://localhost:3000/api/v1/auth/sign_out" \
-H "Authorization: Bearer [JWT_TOKEN]" \
-H "Content-Type: application/json"