### PR TITLE
feature/#249-add-password-reset-for-api

### DIFF
--- a/api/app/controllers/api/v1/auth/passwords_controller.rb
+++ b/api/app/controllers/api/v1/auth/passwords_controller.rb
@@ -4,6 +4,7 @@ module Api
       class PasswordsController < Devise::PasswordsController
         respond_to :json
 
+        # createアクション
         def create
           self.resource = resource_class.send_reset_password_instructions(resource_params)
 
@@ -19,10 +20,26 @@ module Api
           end
         end
 
+        # updateアクション
+        def update
+          self.resource = resource_class.reset_password_by_token(resource_params)
+
+          if resource.errors.empty?
+            render json: {
+              message: 'パスワードを更新しました'
+            }, status: :ok
+          else
+            render json: {
+              message: 'パスワードの更新に失敗しました',
+              errors: resource.errors.full_messages
+            }, status: :unprocessable_entity
+          end
+        end
+
         private
 
         def resource_params
-          params.require(:user).permit(:email)
+          params.require(:user).permit(:email, :password, :password_confirmation, :reset_password_token)
         end
       end
     end

--- a/api/app/mailers/devise_mailer.rb
+++ b/api/app/mailers/devise_mailer.rb
@@ -16,4 +16,19 @@ class DeviseMailer < Devise::Mailer
 
     super
   end
+
+  # パスワードリセット用のメソッドを追加
+  def reset_password_instructions(record, token, opts={})
+    @token = token
+    @resource = record
+    @frontend_url = Rails.env.production? ?
+      ENV.fetch('FRONTEND_URL', 'https://www.osakana-calendar.com') :
+      'http://localhost:5173'
+
+    opts[:subject] = 'パスワード再設定の手順'
+    opts[:from] = ENV.fetch('MAILER_FROM', 'info@osakana-calendar.com')
+    opts[:reply_to] = ENV.fetch('MAILER_FROM', 'info@osakana-calendar.com')
+
+    super
+  end
 end

--- a/api/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/api/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -2,7 +2,7 @@
 
 <p>パスワードの再設定を受け付けました。以下のリンクをクリックして、新しいパスワードを設定してください：</p>
 
-<p><%= link_to 'パスワードを再設定する', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to 'パスワードを再設定する', "#{@frontend_url}/reset-password?reset_password_token=#{@token}" %></p>
 
 <p>このメールに心当たりがない場合は、無視していただいて構いません。</p>
 <p>上記のリンクにアクセスして新しいパスワードを設定するまで、パスワードは変更されません。</p>


### PR DESCRIPTION
# パスワードリセット機能の実装

## 関連Issue
ログイン状態の管理
[#249](https://github.com/Kuriyama301/osakana-calendar/issues/249)

## 変更内容

1. バックエンド実装（API）
- パスワードリセット機能の追加
  - Passwords Controllerの実装
  - リセットトークン管理の実装
  - メール送信機能の統合
- メール送信機能の実装
  - DeviseMailerのカスタマイズ
  - パスワードリセットメールテンプレートの作成

2. ルーティングの設定
- Deviseルートの追加
  - パスワードリセット用エンドポイントの設定
  - APIネームスペースの整理
  
  テスト
  
 - パスワードリセットメール送信
curl -X POST http://localhost:3000/api/v1/auth/password \
-H "Content-Type: application/json" \
-d '{"user": {"email": "test@example.com"}}'

- パスワード更新
curl -X PUT http://localhost:3000/api/v1/auth/password \
-H "Content-Type: application/json" \
-d '{
  "user": {
    "reset_password_token": "TOKEN",
    "password": "new_password123",
    "password_confirmation": "new_password123"
  }
}'
  