### PR TITLE
Feature/#192 add favorites

### DIFF
--- a/api/app/controllers/api/v1/favorites_controller.rb
+++ b/api/app/controllers/api/v1/favorites_controller.rb
@@ -1,0 +1,25 @@
+class Api::V1::FavoritesController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @favorites = current_user.favorite_fishes
+    render json: @favorites.as_json(include: :fish_seasons, methods: :image_url)
+  end
+
+  def create
+    @favorite = current_user.favorites.build(fish_id: params[:fish_id])
+    if @favorite.save
+      render json: @favorite.fish.as_json(include: :fish_seasons, methods: :image_url), status: :created
+    else
+      render json: { error: @favorite.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @favorite = current_user.favorites.find_by!(fish_id: params[:id])
+    @favorite.destroy
+    head :no_content
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: 'Favorite not found' }, status: :not_found
+  end
+end

--- a/api/app/models/favorite.rb
+++ b/api/app/models/favorite.rb
@@ -1,0 +1,5 @@
+class Favorite < ApplicationRecord
+  belongs_to :user
+  belongs_to :fish
+  validates :user_id, uniqueness: { scope: :fish_id }
+end

--- a/api/app/models/fish.rb
+++ b/api/app/models/fish.rb
@@ -2,6 +2,10 @@ class Fish < ApplicationRecord
   has_many :fish_seasons
   has_one_attached :image
 
+  # アソシエーションの追加
+  has_many :favorites, dependent: :destroy
+  has_many :favorited_by_users, through: :favorites, source: :user
+
   # 特定の日付の旬の魚を取得するスコープ
   scope :in_season_on, ->(date) {
     joins(:fish_seasons).where(

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -17,4 +17,8 @@ class User < ApplicationRecord
       'name' => name
     })
   end
+
+  # アソシエーション
+  has_many :favorites, dependent: :destroy
+  has_many :favorite_fishes, through: :favorites, source: :fish
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -24,6 +24,9 @@ Rails.application.routes.draw do
 
       # カレンダー関連
       get 'calendar/fish', to: 'calendar#fish_by_date'
+
+      # お気に入り関連
+      resources :favorites, only: [:index, :create, :destroy]
     end
   end
 end

--- a/api/db/migrate/20241222111108_create_favorites.rb
+++ b/api/db/migrate/20241222111108_create_favorites.rb
@@ -1,0 +1,8 @@
+class CreateFavorites < ActiveRecord::Migration[7.0]
+  def change
+    create_table :favorites do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/api/db/migrate/20241222111108_create_favorites.rb
+++ b/api/db/migrate/20241222111108_create_favorites.rb
@@ -1,8 +1,11 @@
 class CreateFavorites < ActiveRecord::Migration[7.0]
   def change
     create_table :favorites do |t|
-
+      t.references :user, null: false, foreign_key: true
+      t.references :fish, null: false, foreign_key: true
       t.timestamps
+
+      t.index [:user_id, :fish_id], unique: true
     end
   end
 end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -43,8 +43,13 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_22_111108) do
   end
 
   create_table "favorites", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "fish_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["fish_id"], name: "index_favorites_on_fish_id"
+    t.index ["user_id", "fish_id"], name: "index_favorites_on_user_id_and_fish_id", unique: true
+    t.index ["user_id"], name: "index_favorites_on_user_id"
   end
 
   create_table "fish", force: :cascade do |t|
@@ -102,5 +107,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_22_111108) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "favorites", "fish"
+  add_foreign_key "favorites", "users"
   add_foreign_key "fish_seasons", "fish"
 end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_12_01_013529) do
+ActiveRecord::Schema[7.0].define(version: 2024_12_22_111108) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,6 +40,11 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_01_013529) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "favorites", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "fish", force: :cascade do |t|


### PR DESCRIPTION
# お気に入り機能のバックエンド実装

## 関連Issue
お気に入り機能の追加
[#192](https://github.com/Kuriyama301/osakana-calendar/issues/192)

## 変更内容

1. お気に入りテーブルの作成
- マイグレーションファイルの作成と実行
 - ユーザーと魚の関連付けテーブル
 - ユニーク制約の追加

2. モデルの実装
- Favoriteモデルの作成
- User, Fishモデルとの関連付け設定

3. コントローラーの実装
- Favorites Controllerの作成
- お気に入りの追加・削除・一覧取得機能の実装

4. ルーティングの設定
- お気に入り機能用のAPIエンドポイント追加

テスト
```
# お気に入り一覧の取得
curl -X GET http://localhost:3000/api/v1/favorites \
  -H "Authorization: Bearer YOUR_JWT_TOKEN"

# お気に入りの追加
curl -X POST http://localhost:3000/api/v1/favorites \
  -H "Authorization: Bearer YOUR_JWT_TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"fish_id": 1}'

# お気に入りの削除
curl -X DELETE http://localhost:3000/api/v1/favorites/1 \
  -H "Authorization: Bearer YOUR_JWT_TOKEN"
  ```