### PR TITLE
feature/#192 add faborites for front

### DIFF
--- a/api/app/controllers/api/v1/favorites_controller.rb
+++ b/api/app/controllers/api/v1/favorites_controller.rb
@@ -11,7 +11,41 @@ class Api::V1::FavoritesController < ApplicationController
     }
   end
 
+  def create
+    fish_id = params[:fish_id] || params.dig(:favorite, :fish_id)
+    @favorite = current_user.favorites.build(fish_id: fish_id)
+
+    if @favorite.save
+      fish = @favorite.fish.as_json(
+        include: :fish_seasons,
+        methods: :image_url
+      )
+      render json: fish, status: :created
+    else
+      Rails.logger.debug "Favorite validation errors: #{@favorite.errors.full_messages}" # デバッグログ追加
+      render json: {
+        error: @favorite.errors.full_messages
+      }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @favorite = current_user.favorites.find_by!(fish_id: params[:id])
+
+    if @favorite.destroy
+      head :no_content
+    else
+      render json: { error: "Failed to remove favorite" }, status: :unprocessable_entity
+    end
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: "Favorite not found" }, status: :not_found
+  end
+
   private
+
+  def favorite_params
+    params.permit(:fish_id, favorite: [:fish_id])
+  end
 
   def set_active_storage_current
     return if Rails.env.production?

--- a/front/app/src/App.jsx
+++ b/front/app/src/App.jsx
@@ -5,7 +5,8 @@ import HomePage from "./pages/HomePage";
 import { CalendarProvider } from "./CalendarContext.jsx";
 import LoadingScreen from "./components/Common/LoadingScreen.jsx";
 import { AuthProvider } from "./contexts/AuthContext";
-import EmailConfirmation from "./components/Auth/EmailConfirmation"; // 追加
+import { FavoritesProvider } from "./contexts/FavoritesContext";
+import EmailConfirmation from "./components/Auth/EmailConfirmation";
 
 class ErrorBoundary extends Component {
   constructor(props) {
@@ -74,24 +75,26 @@ function App() {
   return (
     <ErrorBoundary>
       <AuthProvider>
-        <CalendarProvider>
-          <Router>
-            <div className="h-screen overflow-hidden">
-              <LoadingScreen isOpen={isInitialLoading} />
-              <Suspense fallback={<LoadingScreen isOpen={true} />}>
-                <main className="h-full">
-                  <Routes>
-                    <Route path="/" element={<HomePage />} />
-                    <Route
-                      path="/auth/confirm"
-                      element={<EmailConfirmation />}
-                    />{" "}
-                  </Routes>
-                </main>
-              </Suspense>
-            </div>
-          </Router>
-        </CalendarProvider>
+        <FavoritesProvider>
+          <CalendarProvider>
+            <Router>
+              <div className="h-screen overflow-hidden">
+                <LoadingScreen isOpen={isInitialLoading} />
+                <Suspense fallback={<LoadingScreen isOpen={true} />}>
+                  <main className="h-full">
+                    <Routes>
+                      <Route path="/" element={<HomePage />} />
+                      <Route
+                        path="/auth/confirm"
+                        element={<EmailConfirmation />}
+                      />
+                    </Routes>
+                  </main>
+                </Suspense>
+              </div>
+            </Router>
+          </CalendarProvider>
+        </FavoritesProvider>
       </AuthProvider>
     </ErrorBoundary>
   );

--- a/front/app/src/api/favorites.js
+++ b/front/app/src/api/favorites.js
@@ -1,0 +1,34 @@
+import client from "./client";
+
+export const favoritesAPI = {
+  getFavorites: async () => {
+    try {
+      const response = await client.get("/api/v1/favorites");
+      return response.data;
+    } catch (error) {
+      console.error("Failed to fetch favorites:", error);
+      throw error;
+    }
+  },
+
+  addFavorite: async (fishId) => {
+    try {
+      const response = await client.post("/api/v1/favorites", {
+        fish_id: fishId,
+      });
+      return response.data;
+    } catch (error) {
+      console.error("Failed to add favorite:", error);
+      throw error;
+    }
+  },
+
+  removeFavorite: async (fishId) => {
+    try {
+      await client.delete(`/api/v1/favorites/${fishId}`);
+    } catch (error) {
+      console.error("Failed to remove favorite:", error);
+      throw error;
+    }
+  },
+};

--- a/front/app/src/components/Fish/FavoriteButton.jsx
+++ b/front/app/src/components/Fish/FavoriteButton.jsx
@@ -38,16 +38,16 @@ const FavoriteButton = ({ fishId }) => {
     <button
       onClick={handleClick}
       disabled={isLoading}
-      className="flex items-center justify-center bg-transparent transform-none" // transform-noneを追加
+      className="flex items-center justify-center bg-transparent transform-none"
       style={{ padding: "8px" }}
       aria-label={isFavorited ? "お気に入りから削除" : "お気に入りに追加"}
     >
       <Heart
-        className={`w-6 h-6 transform-none ${
+        className={`w-4 h-4 transform-none ${
           isLoading
             ? "text-gray-300"
             : isFavorited
-            ? "fill-red-500 text-red-500"
+            ? "fill-pink-500 text-pink-500"
             : "text-gray-400"
         }`}
       />

--- a/front/app/src/components/Fish/FavoriteButton.jsx
+++ b/front/app/src/components/Fish/FavoriteButton.jsx
@@ -1,0 +1,62 @@
+import React, { useState, useEffect } from "react";
+import PropTypes from "prop-types";
+import { Heart } from "lucide-react";
+import { useAuth } from "../../contexts/AuthContext";
+import { useFavorites } from "../../contexts/FavoritesContext";
+
+const FavoriteButton = ({ fishId }) => {
+  const [isLoading, setIsLoading] = useState(false);
+  const { isAuthenticated } = useAuth();
+  const { favorites, addFavorite, removeFavorite } = useFavorites();
+  const [isFavorited, setIsFavorited] = useState(false);
+
+  useEffect(() => {
+    setIsFavorited(favorites.some((fish) => fish.id === fishId));
+  }, [favorites, fishId]);
+
+  const handleClick = async (e) => {
+    e.stopPropagation();
+    if (!isAuthenticated()) return;
+
+    setIsLoading(true);
+    try {
+      if (isFavorited) {
+        await removeFavorite(fishId);
+      } else {
+        await addFavorite(fishId);
+      }
+    } catch (error) {
+      console.error("Favorite operation failed:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (!isAuthenticated()) return null;
+
+  return (
+    <button
+      onClick={handleClick}
+      disabled={isLoading}
+      className="flex items-center justify-center bg-transparent transform-none" // transform-noneを追加
+      style={{ padding: "8px" }}
+      aria-label={isFavorited ? "お気に入りから削除" : "お気に入りに追加"}
+    >
+      <Heart
+        className={`w-6 h-6 transform-none ${
+          isLoading
+            ? "text-gray-300"
+            : isFavorited
+            ? "fill-red-500 text-red-500"
+            : "text-gray-400"
+        }`}
+      />
+    </button>
+  );
+};
+
+FavoriteButton.propTypes = {
+  fishId: PropTypes.number.isRequired,
+};
+
+export default FavoriteButton;

--- a/front/app/src/components/Fish/FavoritesModal.jsx
+++ b/front/app/src/components/Fish/FavoritesModal.jsx
@@ -1,0 +1,109 @@
+import { useState, useEffect } from "react";
+import PropTypes from "prop-types";
+import { X } from "lucide-react";
+import { useFavorites } from "../../contexts/FavoritesContext";
+import SeasonTerm from "./SeasonTerm";
+import FishDetails from "./FishDetails";
+import { useModal } from "../../hooks/useModal";
+
+const FavoritesModal = ({ isOpen, onClose }) => {
+  const { favorites, isLoading, fetchFavorites } = useFavorites();
+  const [selectedFish, setSelectedFish] = useState(null);
+  const [isFishDetailsOpen, setIsFishDetailsOpen] = useState(false);
+  const { isAnimating, shouldRender } = useModal(isOpen);
+  const [imageErrors, setImageErrors] = useState({});
+
+  useEffect(() => {
+    if (isOpen) {
+      fetchFavorites();
+    }
+  }, [isOpen, fetchFavorites]);
+
+  const handleFishClick = (fish) => {
+    setSelectedFish(fish);
+    setIsFishDetailsOpen(true);
+  };
+
+  const handleImageError = (fishId) => {
+    setImageErrors((prev) => ({ ...prev, [fishId]: true }));
+  };
+
+  if (!shouldRender) return null;
+
+  return (
+    <div
+      className={`fixed inset-0 bg-black transition-opacity duration-300 ease-in-out ${
+        isAnimating ? "bg-opacity-50" : "bg-opacity-0"
+      } flex items-center justify-center z-50`}
+      onClick={onClose}
+    >
+      <div
+        className={`bg-white rounded-lg text-gray-800 relative w-full mx-4 sm:mx-8 md:mx-auto md:max-w-2xl max-h-[90vh] flex flex-col overflow-hidden transform transition-all duration-300 ease-in-out ${
+          isAnimating ? "scale-100 opacity-100" : "scale-95 opacity-0"
+        }`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="sticky top-0 bg-white z-10 p-4 sm:p-6 border-b border-gray-200">
+          <h2 className="text-xl sm:text-2xl font-bold text-gray-800 pr-8">
+            お気に入りの魚
+          </h2>
+          <button
+            onClick={onClose}
+            className="absolute top-2 right-2 sm:top-4 sm:right-4 text-gray-600 hover:bg-gray-100 rounded-full p-2 transition-colors duration-200"
+            aria-label="Close modal"
+          >
+            <X size={24} />
+          </button>
+        </div>
+
+        <div className="flex-grow overflow-y-auto p-4 sm:p-6">
+          {isLoading ? (
+            <div className="text-center py-4">読み込み中...</div>
+          ) : favorites.length === 0 ? (
+            <div className="text-center py-4">お気に入りの魚はありません</div>
+          ) : (
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+              {favorites.map((fish) => (
+                <div
+                  key={fish.id}
+                  className="flex flex-col items-center p-2 cursor-pointer hover:bg-gray-50 rounded-lg"
+                  onClick={() => handleFishClick(fish)}
+                >
+                  {!imageErrors[fish.id] ? (
+                    <img
+                      src={fish.image_url}
+                      alt={fish.name}
+                      className="w-32 h-32 object-contain rounded-lg"
+                      onError={() => handleImageError(fish.id)}
+                    />
+                  ) : (
+                    <div className="w-32 h-32 bg-gray-200 flex items-center justify-center rounded-lg">
+                      <span className="text-sm text-gray-600">{fish.name}</span>
+                    </div>
+                  )}
+                  <p className="mt-2 text-center font-semibold">{fish.name}</p>
+                  {fish.fish_seasons?.[0] && (
+                    <SeasonTerm season={fish.fish_seasons[0]} />
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <FishDetails
+        isOpen={isFishDetailsOpen}
+        onClose={() => setIsFishDetailsOpen(false)}
+        fish={selectedFish}
+      />
+    </div>
+  );
+};
+
+FavoritesModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default FavoritesModal;

--- a/front/app/src/components/Fish/FavoritesModal.jsx
+++ b/front/app/src/components/Fish/FavoritesModal.jsx
@@ -45,7 +45,7 @@ const FavoritesModal = ({ isOpen, onClose }) => {
       >
         <div className="sticky top-0 bg-white z-10 p-4 sm:p-6 border-b border-gray-200">
           <h2 className="text-xl sm:text-2xl font-bold text-gray-800 pr-8">
-            お気に入りの魚
+            お気に入りのオサカナ
           </h2>
           <button
             onClick={onClose}
@@ -60,7 +60,7 @@ const FavoritesModal = ({ isOpen, onClose }) => {
           {isLoading ? (
             <div className="text-center py-4">読み込み中...</div>
           ) : favorites.length === 0 ? (
-            <div className="text-center py-4">お気に入りの魚はありません</div>
+            <div className="text-center py-4">お気に入りのオサカナはありません</div>
           ) : (
             <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
               {favorites.map((fish) => (

--- a/front/app/src/components/Fish/FishDetails.jsx
+++ b/front/app/src/components/Fish/FishDetails.jsx
@@ -2,7 +2,8 @@ import { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import { X } from "lucide-react";
 import SeasonTerm from "./SeasonTerm";
-import FishVideo from "./FishVideo";  // FishVideoコンポーネントをインポート
+import FishVideo from "./FishVideo";
+import FavoriteButton from "./FavoriteButton";
 
 const FishDetails = ({ isOpen, onClose, fish }) => {
   const [isAnimating, setIsAnimating] = useState(false);
@@ -44,16 +45,22 @@ const FishDetails = ({ isOpen, onClose, fish }) => {
         onClick={(e) => e.stopPropagation()}
       >
         <div className="sticky top-0 bg-white z-10 p-4 sm:p-6 border-b border-gray-200">
-          <h2 className="text-2xl sm:text-3xl font-bold text-gray-800 text-center">
-            {fish?.name}
-          </h2>
-          <button
-            onClick={handleClose}
-            className="absolute top-2 right-2 sm:top-4 sm:right-4 text-gray-600 bg-white hover:bg-gray-300 hover:text-gray-800 rounded-full p-2 transition-colors duration-200"
-            aria-label="Close modal"
-          >
-            <X size={24} />
-          </button>
+          <div className="flex justify-between items-center">
+            <h2 className="text-2xl sm:text-3xl font-bold text-gray-800">
+              {fish?.name}
+            </h2>
+            <div className="flex items-center space-x-2">
+              {fish && <FavoriteButton fishId={fish.id} />}{" "}
+              {/* FavoriteButtonの追加 */}
+              <button
+                onClick={handleClose}
+                className="text-gray-600 hover:bg-gray-100 rounded-full p-2 transition-colors duration-200"
+                aria-label="Close modal"
+              >
+                <X size={24} />
+              </button>
+            </div>
+          </div>
         </div>
 
         <div className="flex-grow overflow-y-auto scrollbar-hide p-4 sm:p-6">
@@ -97,7 +104,6 @@ const FishDetails = ({ isOpen, onClose, fish }) => {
               <h3 className="text-xl font-semibold mb-2">特徴</h3>
               <p className="text-lg text-gray-700 mb-4">{fish?.features}</p>
 
-              {/* YouTube動画セクション */}
               <div className="mt-6">
                 <FishVideo fishName={fish?.name} />
               </div>
@@ -113,6 +119,7 @@ FishDetails.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   fish: PropTypes.shape({
+    id: PropTypes.number,
     name: PropTypes.string,
     image_url: PropTypes.string,
     fish_seasons: PropTypes.arrayOf(

--- a/front/app/src/components/Fish/SearchModal.jsx
+++ b/front/app/src/components/Fish/SearchModal.jsx
@@ -83,7 +83,7 @@ const SearchModal = ({ isOpen, onClose, searchResults }) => {
               {searchResults.map((fish) => (
                 <div
                   key={fish.id}
-                  className="flex flex-col items-center justify-center text-center cursor-pointer transition-transform duration-200 hover:scale-105"
+                  className="flex flex-col items-center justify-center text-center cursor-pointer transition-transform duration-200 "
                   onClick={() => handleFishClick(fish)}
                 >
                   {/* 魚の画像表示 */}

--- a/front/app/src/components/Fish/SeasonalFishModal.jsx
+++ b/front/app/src/components/Fish/SeasonalFishModal.jsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from "react";
-import PropTypes from 'prop-types';
+import PropTypes from "prop-types";
 import { X } from "lucide-react";
-import SeasonTerm from './SeasonTerm';
-import FishDetails from './FishDetails';
+import SeasonTerm from "./SeasonTerm";
+import FishDetails from "./FishDetails";
+import FavoriteButton from "./FavoriteButton";
 
 const SeasonalFishModal = ({
   isOpen,
@@ -37,9 +38,9 @@ const SeasonalFishModal = ({
   };
 
   const handleImageError = (fishId, fishName) => {
-    setImageErrors(prev => ({
+    setImageErrors((prev) => ({
       ...prev,
-      [fishId]: true
+      [fishId]: true,
     }));
     console.log(`Image loading failed for ${fishName}`);
   };
@@ -49,15 +50,15 @@ const SeasonalFishModal = ({
   if (!isAnimating && !isOpen) return null;
 
   return (
-    <div 
+    <div
       className={`fixed inset-0 bg-black transition-opacity duration-300 ease-in-out ${
-        isAnimating && isOpen ? 'bg-opacity-50' : 'bg-opacity-0'
+        isAnimating && isOpen ? "bg-opacity-50" : "bg-opacity-0"
       } flex items-center justify-center z-50`}
       onClick={handleCloseSeasonalFishModal}
     >
-      <div 
+      <div
         className={`bg-white rounded-lg text-gray-800 relative w-full mx-4 sm:mx-8 md:mx-auto md:max-w-2xl max-h-[90vh] flex flex-col overflow-hidden transform transition-all duration-300 ease-in-out ${
-          isAnimating && isOpen ? 'scale-100 opacity-100' : 'scale-95 opacity-0'
+          isAnimating && isOpen ? "scale-100 opacity-100" : "scale-95 opacity-0"
         }`}
         onClick={(e) => e.stopPropagation()}
       >
@@ -82,26 +83,34 @@ const SeasonalFishModal = ({
           ) : filteredFish.length > 0 ? (
             <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 sm:gap-6">
               {filteredFish.map((fish) => (
-                <div 
-                  key={fish.id} 
-                  className="flex flex-col items-center justify-center text-center cursor-pointer transition-transform duration-200 hover:scale-105"
+                <div
+                  key={fish.id}
+                  className="flex flex-col items-center justify-center text-center cursor-pointer transition-transform duration-200 hover:scale-105 relative"
                   onClick={() => handleFishClick(fish)}
                 >
-                  <div className="w-32 h-32 sm:w-40 sm:h-40 flex items-center justify-center mb-2">
+                  <div className="w-32 h-32 sm:w-40 sm:h-40 flex items-center justify-center mb-2 relative">
                     {!imageErrors[fish.id] ? (
-                      <img 
+                      <img
                         src={fish.image_url}
-                        alt={fish.name} 
+                        alt={fish.name}
                         className="max-w-full max-h-full object-contain rounded-lg"
                         onError={() => handleImageError(fish.id, fish.name)}
                       />
                     ) : (
                       <div className="w-full h-full bg-gray-200 flex items-center justify-center rounded-lg">
-                        <span className="text-sm text-gray-600">{fish.name}</span>
+                        <span className="text-sm text-gray-600">
+                          {fish.name}
+                        </span>
                       </div>
                     )}
+                    <div className="absolute bottom-0 right-0 bg-transparent z-10 transform-none">
+                      {" "}
+                      <FavoriteButton fishId={fish.id} />
+                    </div>
                   </div>
-                  <p className="font-semibold text-gray-800 text-sm sm:text-base">{fish.name}</p>
+                  <p className="font-semibold text-gray-800 text-sm sm:text-base">
+                    {fish.name}
+                  </p>
                   {fish.fish_seasons && fish.fish_seasons.length > 0 ? (
                     fish.fish_seasons.map((season, index) => (
                       <SeasonTerm key={index} season={season} />
@@ -141,13 +150,13 @@ SeasonalFishModal.propTypes = {
           start_month: PropTypes.number.isRequired,
           start_day: PropTypes.number.isRequired,
           end_month: PropTypes.number.isRequired,
-          end_day: PropTypes.number.isRequired
+          end_day: PropTypes.number.isRequired,
         })
-      ).isRequired
+      ).isRequired,
     })
   ).isRequired,
   isLoading: PropTypes.bool.isRequired,
-  error: PropTypes.string
+  error: PropTypes.string,
 };
 
 export default SeasonalFishModal;

--- a/front/app/src/components/Fish/SeasonalFishModal.jsx
+++ b/front/app/src/components/Fish/SeasonalFishModal.jsx
@@ -4,6 +4,7 @@ import { X } from "lucide-react";
 import SeasonTerm from "./SeasonTerm";
 import FishDetails from "./FishDetails";
 import FavoriteButton from "./FavoriteButton";
+import { useFavorites } from "../../contexts/FavoritesContext";
 
 const SeasonalFishModal = ({
   isOpen,
@@ -17,15 +18,17 @@ const SeasonalFishModal = ({
   const [isFishDetailsOpen, setIsFishDetailsOpen] = useState(false);
   const [isAnimating, setIsAnimating] = useState(false);
   const [imageErrors, setImageErrors] = useState({});
+  const { fetchFavorites } = useFavorites();
 
   useEffect(() => {
     if (isOpen) {
       setIsAnimating(true);
+      fetchFavorites();
     } else {
       const timer = setTimeout(() => setIsAnimating(false), 300);
       return () => clearTimeout(timer);
     }
-  }, [isOpen]);
+  }, [isOpen, fetchFavorites]);
 
   const handleFishClick = (fish) => {
     setSelectedFish(fish);
@@ -85,10 +88,10 @@ const SeasonalFishModal = ({
               {filteredFish.map((fish) => (
                 <div
                   key={fish.id}
-                  className="flex flex-col items-center justify-center text-center cursor-pointer transition-transform duration-200 hover:scale-105 relative"
+                  className="flex flex-col items-center justify-center text-center cursor-pointer transition-transform duration-200 relative"
                   onClick={() => handleFishClick(fish)}
                 >
-                  <div className="w-32 h-32 sm:w-40 sm:h-40 flex items-center justify-center mb-2 relative">
+                  <div className="w-32 h-32 sm:w-40 sm:h-40 flex items-center justify-center mb-2">
                     {!imageErrors[fish.id] ? (
                       <img
                         src={fish.image_url}
@@ -103,14 +106,16 @@ const SeasonalFishModal = ({
                         </span>
                       </div>
                     )}
-                    <div className="absolute bottom-0 right-0 bg-transparent z-10 transform-none">
-                      {" "}
+                  </div>
+                  {/* 魚の名前とお気に入りボタンを横並びに */}
+                  <div className="flex items-center space-x-2 mb-1">
+                    <p className="font-semibold text-gray-800 text-sm sm:text-base">
+                      {fish.name}
+                    </p>
+                    <div onClick={(e) => e.stopPropagation()}>
                       <FavoriteButton fishId={fish.id} />
                     </div>
                   </div>
-                  <p className="font-semibold text-gray-800 text-sm sm:text-base">
-                    {fish.name}
-                  </p>
                   {fish.fish_seasons && fish.fish_seasons.length > 0 ? (
                     fish.fish_seasons.map((season, index) => (
                       <SeasonTerm key={index} season={season} />

--- a/front/app/src/components/Fish/__tests__/SeasonalFishModal.test.jsx
+++ b/front/app/src/components/Fish/__tests__/SeasonalFishModal.test.jsx
@@ -1,18 +1,34 @@
 import { render, screen } from "@testing-library/react";
 import SeasonalFishModal from "../SeasonalFishModal";
+import { FavoritesProvider } from "../../../contexts/FavoritesContext";
+
+// FavoritesContextのモックを作成
+vi.mock("../../../contexts/FavoritesContext", () => ({
+  useFavorites: () => ({
+    favorites: [],
+    fetchFavorites: vi.fn(),
+    addFavorite: vi.fn(),
+    removeFavorite: vi.fn(),
+  }),
+  FavoritesProvider: ({ children }) => children,
+}));
 
 describe("SeasonalFishModal", () => {
-  const mockFish = [{
-    id: 1,
-    name: "サンマ",
-    image_url: "/test-image.jpg", // image_urlを追加
-    fish_seasons: [{
-      start_month: 9,
-      start_day: 1,
-      end_month: 11,
-      end_day: 30,
-    }],
-  }];
+  const mockFish = [
+    {
+      id: 1,
+      name: "サンマ",
+      image_url: "/test-image.jpg",
+      fish_seasons: [
+        {
+          start_month: 9,
+          start_day: 1,
+          end_month: 11,
+          end_day: 30,
+        },
+      ],
+    },
+  ];
 
   const defaultProps = {
     isOpen: true,
@@ -23,18 +39,29 @@ describe("SeasonalFishModal", () => {
     error: null,
   };
 
+  // コンポーネントをProviderでラップするヘルパー関数
+  const renderWithProviders = (props) => {
+    return render(
+      <FavoritesProvider>
+        <SeasonalFishModal {...props} />
+      </FavoritesProvider>
+    );
+  };
+
   test("モーダルが開いているときに日付が表示される", () => {
-    render(<SeasonalFishModal {...defaultProps} />);
+    renderWithProviders(defaultProps);
     expect(screen.getByText("2024年1月1日の旬の魚")).toBeInTheDocument();
   });
 
   test("魚のリストが表示される", () => {
-    render(<SeasonalFishModal {...defaultProps} seasonalFish={mockFish} />);
+    renderWithProviders({ ...defaultProps, seasonalFish: mockFish });
     expect(screen.getByText("サンマ")).toBeInTheDocument();
   });
 
   test("データが空の場合適切なメッセージが表示される", () => {
-    render(<SeasonalFishModal {...defaultProps} seasonalFish={[]} />);
-    expect(screen.getByText("この日付の旬の魚はありません。")).toBeInTheDocument();
+    renderWithProviders({ ...defaultProps, seasonalFish: [] });
+    expect(
+      screen.getByText("この日付の旬の魚はありません。")
+    ).toBeInTheDocument();
   });
 });

--- a/front/app/src/components/Fish/__tests__/SeasonalFishModal.test.jsx
+++ b/front/app/src/components/Fish/__tests__/SeasonalFishModal.test.jsx
@@ -1,8 +1,9 @@
 import { render, screen } from "@testing-library/react";
 import SeasonalFishModal from "../SeasonalFishModal";
 import { FavoritesProvider } from "../../../contexts/FavoritesContext";
+import { AuthProvider } from "../../../contexts/AuthContext";
 
-// FavoritesContextのモックを作成
+// 両方のContextのモックを作成
 vi.mock("../../../contexts/FavoritesContext", () => ({
   useFavorites: () => ({
     favorites: [],
@@ -11,6 +12,13 @@ vi.mock("../../../contexts/FavoritesContext", () => ({
     removeFavorite: vi.fn(),
   }),
   FavoritesProvider: ({ children }) => children,
+}));
+
+vi.mock("../../../contexts/AuthContext", () => ({
+  useAuth: () => ({
+    isAuthenticated: () => true,
+  }),
+  AuthProvider: ({ children }) => children,
 }));
 
 describe("SeasonalFishModal", () => {
@@ -39,12 +47,14 @@ describe("SeasonalFishModal", () => {
     error: null,
   };
 
-  // コンポーネントをProviderでラップするヘルパー関数
+  // 両方のProviderでラップするヘルパー関数
   const renderWithProviders = (props) => {
     return render(
-      <FavoritesProvider>
-        <SeasonalFishModal {...props} />
-      </FavoritesProvider>
+      <AuthProvider>
+        <FavoritesProvider>
+          <SeasonalFishModal {...props} />
+        </FavoritesProvider>
+      </AuthProvider>
     );
   };
 

--- a/front/app/src/contexts/FavoritesContext.jsx
+++ b/front/app/src/contexts/FavoritesContext.jsx
@@ -1,0 +1,73 @@
+import { createContext, useContext, useState, useCallback } from "react";
+import PropTypes from "prop-types";
+import { favoritesAPI } from "../api/favorites";
+
+const FavoritesContext = createContext(null);
+
+export const FavoritesProvider = ({ children }) => {
+  const [favorites, setFavorites] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const fetchFavorites = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const data = await favoritesAPI.getFavorites();
+      setFavorites(data);
+    } catch (error) {
+      console.error("Failed to fetch favorites:", error);
+      setFavorites([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const addFavorite = useCallback(
+    async (fishId) => {
+      try {
+        await favoritesAPI.addFavorite(fishId);
+        await fetchFavorites();
+      } catch (error) {
+        console.error("Failed to add favorite:", error);
+      }
+    },
+    [fetchFavorites]
+  );
+
+  const removeFavorite = useCallback(
+    async (fishId) => {
+      try {
+        await favoritesAPI.removeFavorite(fishId);
+        await fetchFavorites();
+      } catch (error) {
+        console.error("Failed to remove favorite:", error);
+      }
+    },
+    [fetchFavorites]
+  );
+
+  const value = {
+    favorites,
+    isLoading,
+    fetchFavorites,
+    addFavorite,
+    removeFavorite,
+  };
+
+  return (
+    <FavoritesContext.Provider value={value}>
+      {children}
+    </FavoritesContext.Provider>
+  );
+};
+
+FavoritesProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export const useFavorites = () => {
+  const context = useContext(FavoritesContext);
+  if (!context) {
+    throw new Error("useFavorites must be used within a FavoritesProvider");
+  }
+  return context;
+};

--- a/front/app/src/contexts/FavoritesContext.jsx
+++ b/front/app/src/contexts/FavoritesContext.jsx
@@ -1,4 +1,10 @@
-import { createContext, useContext, useState, useCallback } from "react";
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+} from "react";
 import PropTypes from "prop-types";
 import { favoritesAPI } from "../api/favorites";
 
@@ -25,9 +31,12 @@ export const FavoritesProvider = ({ children }) => {
     async (fishId) => {
       try {
         await favoritesAPI.addFavorite(fishId);
-        await fetchFavorites();
+        await fetchFavorites(); // 成功後に一覧を更新
       } catch (error) {
         console.error("Failed to add favorite:", error);
+        if (error.response?.status === 422) {
+          await fetchFavorites();
+        }
       }
     },
     [fetchFavorites]
@@ -44,6 +53,14 @@ export const FavoritesProvider = ({ children }) => {
     },
     [fetchFavorites]
   );
+
+  // 初期データを取得
+  useEffect(() => {
+    const initializeFavorites = async () => {
+      await fetchFavorites();
+    };
+    initializeFavorites();
+  }, []); // fetchFavorites（無限ループ防止）
 
   const value = {
     favorites,
@@ -71,3 +88,5 @@ export const useFavorites = () => {
   }
   return context;
 };
+
+export default FavoritesContext;

--- a/front/app/src/index.css
+++ b/front/app/src/index.css
@@ -38,7 +38,7 @@ h1 {
   line-height: 1.1;
 }
 
-button {
+button.default-button {
   border-radius: 8px;
   border: 1px solid transparent;
   padding: 0.6em 1.2em;
@@ -49,11 +49,13 @@ button {
   cursor: pointer;
   transition: border-color 0.25s;
 }
-button:hover {
+
+button.default-button:hover {
   border-color: #646cff;
 }
-button:focus,
-button:focus-visible {
+
+button.default-button:focus,
+button.default-button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 

--- a/front/app/src/pages/HomePage.jsx
+++ b/front/app/src/pages/HomePage.jsx
@@ -5,14 +5,19 @@ import { Home, Utensils, Heart, HelpCircle } from "lucide-react";
 import SeasonalFishModal from "../components/Fish/SeasonalFishModal";
 import SearchForm from "../components/Fish/SearchForm";
 import SearchModal from "../components/Fish/SearchModal";
+import FavoritesModal from "../components/Fish/FavoritesModal";
 import { searchFish } from "../api/fish";
 import { useDailyFishModal } from "../hooks/useDailyFishModal";
 import LoadingScreen from "../components/Common/LoadingScreen";
 import AuthNavItem from "../components/Common/AuthNavItem";
 import AuthModal from "../components/Auth/AuthModal";
+import { useAuth } from "../contexts/AuthContext";
 
-const NavItem = ({ icon, label }) => (
-  <li className="flex items-center space-x-3 p-3 hover:bg-blue-50 rounded-lg cursor-pointer transition-colors">
+const NavItem = ({ icon, label, onClick }) => (
+  <li
+    className="flex items-center space-x-3 p-3 hover:bg-blue-50 rounded-lg cursor-pointer transition-colors"
+    onClick={onClick}
+  >
     <span className="text-gray-600">{icon}</span>
     <span className="font-medium text-gray-700">{label}</span>
   </li>
@@ -22,12 +27,15 @@ const NavItem = ({ icon, label }) => (
 NavItem.propTypes = {
   icon: PropTypes.node.isRequired,
   label: PropTypes.string.isRequired,
+  onClick: PropTypes.func,
 };
 
 const HomePage = () => {
   const [showSubCalendar, setShowSubCalendar] = useState(true);
   const [isAuthModalOpen, setIsAuthModalOpen] = useState(false);
+  const [isFavoritesModalOpen, setIsFavoritesModalOpen] = useState(false);
   const containerRef = useRef(null);
+  const { isAuthenticated } = useAuth();
   const {
     isModalOpen: isFishModalOpen,
     selectedModalDate,
@@ -79,6 +87,23 @@ const HomePage = () => {
     };
   }, [checkSize]);
 
+  const navItems = [
+    { icon: <Home size={20} />, label: "HOME" },
+    { icon: <Utensils size={20} />, label: "COLLECTION" },
+    {
+      icon: <Heart size={20} />,
+      label: "FAVORITE",
+      onClick: () => {
+        if (isAuthenticated()) {
+          setIsFavoritesModalOpen(true);
+        } else {
+          setIsAuthModalOpen(true);
+        }
+      },
+    },
+    { icon: <HelpCircle size={20} />, label: "HELP" },
+  ];
+
   return (
     <div
       ref={containerRef}
@@ -98,7 +123,7 @@ const HomePage = () => {
           <div
             className={`${
               showSubCalendar ? "block" : "hidden"
-            } lg:block lg:w-80 fixed left-4 top-6 lg:sticky lg:top-6 lg:left-auto space-y-4 z-[50]`} // z-[100]から z-[50]に変更
+            } lg:block lg:w-80 fixed left-4 top-6 lg:sticky lg:top-6 lg:left-auto space-y-4 z-[50]`}
           >
             {/* ロゴ */}
             <div className="mb-4">
@@ -117,10 +142,14 @@ const HomePage = () => {
             {/* ナビゲーション */}
             <nav className="bg-white p-6 rounded-lg shadow w-full">
               <ul className="space-y-2">
-                <NavItem icon={<Home size={20} />} label="HOME" />
-                <NavItem icon={<Utensils size={20} />} label="COLLECTION" />
-                <NavItem icon={<Heart size={20} />} label="FAVORITE" />
-                <NavItem icon={<HelpCircle size={20} />} label="HELP" />
+                {navItems.map((item, index) => (
+                  <NavItem
+                    key={index}
+                    icon={item.icon}
+                    label={item.label}
+                    onClick={item.onClick}
+                  />
+                ))}
               </ul>
             </nav>
 
@@ -157,7 +186,11 @@ const HomePage = () => {
         </div>
       </div>
 
-      {/* モーダル */}
+      <FavoritesModal
+        isOpen={isFavoritesModalOpen}
+        onClose={() => setIsFavoritesModalOpen(false)}
+      />
+
       <SearchModal
         isOpen={isSearchModalOpen}
         onClose={() => setIsSearchModalOpen(false)}


### PR DESCRIPTION
# お気に入り機能のフロントエンド実装（UI）

## 関連Issue
お気に入り機能UIの追加
[#194](https://github.com/Kuriyama301/osakana-calendar/issues/194)

## 変更内容

1. お気に入り関連のAPI通信モジュールの作成
- favoritesAPIの実装
 - お気に入り一覧取得
 - お気に入り追加
 - お気に入り削除

2. お気に入り状態管理の実装
- FavoritesContextの作成
 - お気に入り状態の管理
 - お気に入り操作のメソッド提供
 - 状態更新の同期処理

3. コンポーネントの実装
- FavoriteButtonコンポーネントの作成
 - お気に入り追加・削除機能
 - 状態に応じたUI表示
- 既存モーダルの更新
 - SeasonalFishModalの改修
 - FishDetailsの改修
 - お気に入りボタンの配置調整

