### PR TITLE
feature/#188-add-google-auth-for-front

### DIFF
--- a/front/app/package.json
+++ b/front/app/package.json
@@ -34,7 +34,8 @@
     "@mui/icons-material": "^5.15.0",
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
-    "js-cookie": "^3.0.5"
+    "js-cookie": "^3.0.5",
+    "@react-oauth/google": "^0.12.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.1.5",

--- a/front/app/src/api/auth.js
+++ b/front/app/src/api/auth.js
@@ -115,6 +115,30 @@ export const authAPI = {
       throw formatError(error);
     }
   },
+
+  googleAuth: async (credential) => {
+    try {
+      const response = await client.post(
+        "/api/v1/auth/google_oauth2/callback",
+        {
+          credential: credential,
+        }
+      );
+
+      const token = response.data.token;
+      if (token) {
+        client.defaults.headers.common["Authorization"] = `Bearer ${token}`;
+      }
+
+      return {
+        user: response.data.data,
+        token: token,
+      };
+    } catch (error) {
+      console.error("Google auth error:", error);
+      throw formatError(error);
+    }
+  },
 };
 
 export default authAPI;

--- a/front/app/src/components/Auth/AuthModal.jsx
+++ b/front/app/src/components/Auth/AuthModal.jsx
@@ -63,7 +63,7 @@ const AuthModal = ({ isOpen, onClose }) => {
           {authMode === "login" ? (
             <>
               <LoginForm
-                onGoogleLogin={handleGoogleAuth}
+                // onGoogleLogin={handleGoogleAuth}
                 onSuccess={handleLoginSuccess}
               />
               <div className="mt-6 text-center">

--- a/front/app/src/components/Auth/LoginForm.jsx
+++ b/front/app/src/components/Auth/LoginForm.jsx
@@ -8,7 +8,7 @@ import PasswordResetModal from "./PasswordResetModal";
 import { authAPI } from "../../api/auth";
 import { tokenManager } from "../../utils/tokenManager";
 
-const LoginForm = ({ onGoogleLogin, onSuccess }) => {
+const LoginForm = ({ onSuccess }) => {
   const { login } = useAuth();
   const [formData, setFormData] = useState({
     email: "",
@@ -200,7 +200,7 @@ const LoginForm = ({ onGoogleLogin, onSuccess }) => {
 };
 
 LoginForm.propTypes = {
-  onGoogleLogin: PropTypes.func.isRequired,
+  // onGoogleLogin: PropTypes.func.isRequired,
   onSuccess: PropTypes.func,
 };
 

--- a/front/app/src/components/Auth/LoginForm.jsx
+++ b/front/app/src/components/Auth/LoginForm.jsx
@@ -2,8 +2,11 @@ import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { X } from "lucide-react";
 import { useAuth } from "../../contexts/AuthContext";
+import { useGoogleLogin } from "@react-oauth/google";
 import SocialAuthButton from "./SocialAuthButton";
 import PasswordResetModal from "./PasswordResetModal";
+import { authAPI } from "../../api/auth";
+import { tokenManager } from "../../utils/tokenManager";
 
 const LoginForm = ({ onGoogleLogin, onSuccess }) => {
   const { login } = useAuth();
@@ -60,6 +63,29 @@ const LoginForm = ({ onGoogleLogin, onSuccess }) => {
     e.preventDefault();
     setShowResetModal(true);
   };
+
+  // GoogleLogin
+  const handleGoogleLogin = useGoogleLogin({
+    onSuccess: async (tokenResponse) => {
+      try {
+        console.log("Google Login Success:", tokenResponse);
+        // tokenResponseの形式を確認
+        const result = await authAPI.googleAuth(tokenResponse.access_token);
+        if (result.token) {
+          tokenManager.setToken(result.token);
+          tokenManager.setUser(result.user);
+          if (onSuccess) {
+            onSuccess();
+          }
+        }
+      } catch (err) {
+        console.error("Google Auth Error:", err);
+        setError(err.message || "Google認証に失敗しました");
+      }
+    },
+    flow: "implicit",
+    scope: "email profile",
+  });
 
   return (
     <>
@@ -156,7 +182,7 @@ const LoginForm = ({ onGoogleLogin, onSuccess }) => {
         </div>
 
         <SocialAuthButton
-          onClick={onGoogleLogin}
+          onClick={handleGoogleLogin}
           type="login"
           disabled={loading}
         />

--- a/front/app/src/components/Auth/SocialAuthButton.jsx
+++ b/front/app/src/components/Auth/SocialAuthButton.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from "react";
+import PropTypes from "prop-types";
 
 // Googleロゴ
 const GoogleIcon = () => (
@@ -24,13 +24,17 @@ const GoogleIcon = () => (
 );
 
 // Googleログイン/登録ボタンコンポーネント
-const SocialAuthButton = ({ onClick, type = "login" }) => {
+const SocialAuthButton = ({ onClick, type = "login", disabled = false }) => {
   const buttonText = type === "login" ? "Googleでログイン" : "Googleで登録";
 
   return (
     <button
       onClick={onClick}
-      className="w-full p-3 bg-white border border-gray-300 rounded-md hover:bg-gray-50 transition-colors flex items-center justify-center gap-2"
+      disabled={disabled}
+      className={`w-full p-3 bg-white border border-gray-300 rounded-md 
+        flex items-center justify-center gap-2
+        ${disabled ? "opacity-50 cursor-not-allowed" : "hover:bg-gray-50"}
+        transition-colors`}
     >
       <GoogleIcon />
       {buttonText}
@@ -41,7 +45,8 @@ const SocialAuthButton = ({ onClick, type = "login" }) => {
 // PropTypesの定義
 SocialAuthButton.propTypes = {
   onClick: PropTypes.func.isRequired,
-  type: PropTypes.oneOf(["login", "register"])
+  type: PropTypes.oneOf(["login", "register"]),
+  disabled: PropTypes.bool,
 };
 
 export default SocialAuthButton;

--- a/front/app/src/main.jsx
+++ b/front/app/src/main.jsx
@@ -1,5 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { GoogleOAuthProvider } from "@react-oauth/google";
 import App from "./App.jsx";
 import "./index.css";
 import { setupOGP } from "./utils/ogpUtils";
@@ -9,6 +10,8 @@ document.addEventListener("DOMContentLoaded", setupOGP);
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
-    <App />
+    <GoogleOAuthProvider clientId={import.meta.env.VITE_GOOGLE_CLIENT_ID}>
+      <App />
+    </GoogleOAuthProvider>
   </StrictMode>
 );


### PR DESCRIPTION
# Google認証のフロントエンド実装

## 関連Issue
Google OAuth2設定
[#188](https://github.com/Kuriyama301/osakana-calendar/issues/188)

## 変更内容

1. Google認証用のパッケージ導入
- @react-oauth/googleの追加
- プロバイダーコンポーネントの設定

2. 認証関連ファイルの更新
- authAPIの拡張
  - Google認証用のエンドポイント追加
  - 認証フローの実装
- LoginFormの更新
  - Google認証ハンドラーの実装
  - エラーハンドリングの追加

3. UIコンポーネントの更新
- SocialAuthButtonの機能拡張
  - Google認証フローとの連携
  - 状態管理の実装