### PR TITLE
feature/#236-add-collection-api

### DIFF
--- a/api/app/models/fish.rb
+++ b/api/app/models/fish.rb
@@ -5,6 +5,8 @@ class Fish < ApplicationRecord
   # アソシエーションの追加
   has_many :favorites, dependent: :destroy
   has_many :favorited_by_users, through: :favorites, source: :user
+  has_many :fish_collections, dependent: :destroy
+  has_many :collected_by_users, through: :fish_collections, source: :user
 
   # 特定の日付の旬の魚を取得するスコープ
   scope :in_season_on, ->(date) {

--- a/api/app/models/fish_collection.rb
+++ b/api/app/models/fish_collection.rb
@@ -1,0 +1,5 @@
+class FishCollection < ApplicationRecord
+  belongs_to :user
+  belongs_to :fish
+  validates :user_id, uniqueness: { scope: :fish_id }
+end

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -23,6 +23,8 @@ class User < ApplicationRecord
   # アソシエーション
   has_many :favorites, dependent: :destroy
   has_many :favorite_fishes, through: :favorites, source: :fish
+  has_many :fish_collections, dependent: :destroy
+  has_many :collected_fishes, through: :fish_collections, source: :fish
 
   # Google OAuth用のメソッドを追加
   def self.from_omniauth(auth)

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -34,6 +34,9 @@ Rails.application.routes.draw do
 
       # お気に入り関連
       resources :favorites, only: [:index, :create, :destroy]
+
+      # 魚コレクション関連
+      resources :fish_collections, only: [:index, :create, :destroy]
     end
   end
 end

--- a/api/db/migrate/20250102081039_create_fish_collections.rb
+++ b/api/db/migrate/20250102081039_create_fish_collections.rb
@@ -1,0 +1,11 @@
+class CreateFishCollections < ActiveRecord::Migration[7.0]
+  def change
+    create_table :fish_collections do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :fish, null: false, foreign_key: true
+      t.timestamps
+
+      t.index [:user_id, :fish_id], unique: true
+    end
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_12_26_122849) do
+ActiveRecord::Schema[7.0].define(version: 2025_01_02_081039) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -60,6 +60,16 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_26_122849) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_fish_on_name", unique: true
+  end
+
+  create_table "fish_collections", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "fish_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["fish_id"], name: "index_fish_collections_on_fish_id"
+    t.index ["user_id", "fish_id"], name: "index_fish_collections_on_user_id_and_fish_id", unique: true
+    t.index ["user_id"], name: "index_fish_collections_on_user_id"
   end
 
   create_table "fish_seasons", force: :cascade do |t|
@@ -112,5 +122,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_26_122849) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "favorites", "fish"
   add_foreign_key "favorites", "users"
+  add_foreign_key "fish_collections", "fish"
+  add_foreign_key "fish_collections", "users"
   add_foreign_key "fish_seasons", "fish"
 end

--- a/front/app/src/api/collections.js
+++ b/front/app/src/api/collections.js
@@ -1,0 +1,34 @@
+import client from "./client";
+
+export const collectionsAPI = {
+  getCollections: async () => {
+    try {
+      const response = await client.get("/api/v1/fish_collections");
+      return response.data;
+    } catch (error) {
+      console.error("Failed to fetch collections:", error);
+      throw error;
+    }
+  },
+
+  addCollection: async (fishId) => {
+    try {
+      const response = await client.post("/api/v1/fish_collections", {
+        fish_id: fishId,
+      });
+      return response.data;
+    } catch (error) {
+      console.error("Failed to add collection:", error);
+      throw error;
+    }
+  },
+
+  removeCollection: async (fishId) => {
+    try {
+      await client.delete(`/api/v1/fish_collections/${fishId}`);
+    } catch (error) {
+      console.error("Failed to remove collection:", error);
+      throw error;
+    }
+  },
+};

--- a/front/app/src/components/Fish/CollectionButton.jsx
+++ b/front/app/src/components/Fish/CollectionButton.jsx
@@ -1,0 +1,68 @@
+import React, { useState, useEffect } from "react";
+import PropTypes from "prop-types";
+import { Utensils } from "lucide-react";
+import { useAuth } from "../../contexts/AuthContext";
+import { useCollections } from "../../contexts/CollectionsContext";
+
+const CollectionButton = ({ fishId }) => {
+  const [isLoading, setIsLoading] = useState(false);
+  const { isAuthenticated } = useAuth();
+  const { collections, addCollection, removeCollection } = useCollections();
+  const [isCollected, setIsCollected] = useState(false);
+
+  // コレクション状態を更新
+  useEffect(() => {
+    if (collections && fishId) {
+      setIsCollected(collections.some((fish) => fish.id === fishId));
+    }
+  }, [collections, fishId]);
+
+  const handleClick = async (e) => {
+    e.stopPropagation();
+    if (!isAuthenticated()) return;
+
+    setIsLoading(true);
+    try {
+      if (isCollected) {
+        await removeCollection(fishId);
+      } else {
+        await addCollection(fishId);
+      }
+    } catch (error) {
+      console.error("Collection operation failed:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 未認証時に空のボタンを返す
+  if (!isAuthenticated()) {
+    return <div style={{ display: "none" }} />;
+  }
+
+  return (
+    <button
+      onClick={handleClick}
+      disabled={isLoading}
+      className="flex items-center justify-center bg-transparent transform-none"
+      style={{ padding: "8px" }}
+      aria-label={isCollected ? "コレクションから削除" : "コレクションに追加"}
+    >
+      <Utensils
+        className={`w-6 h-6 transform-none ${
+          isLoading
+            ? "text-gray-300"
+            : isCollected
+            ? "fill-indigo-300 text-indigo-300"
+            : "text-gray-400"
+        }`}
+      />
+    </button>
+  );
+};
+
+CollectionButton.propTypes = {
+  fishId: PropTypes.number.isRequired,
+};
+
+export default CollectionButton;

--- a/front/app/src/components/Fish/CollectionsModal.jsx
+++ b/front/app/src/components/Fish/CollectionsModal.jsx
@@ -1,0 +1,111 @@
+import { useState, useEffect } from "react";
+import PropTypes from "prop-types";
+import { X } from "lucide-react";
+import { useCollections } from "../../contexts/CollectionsContext";
+import SeasonTerm from "./SeasonTerm";
+import FishDetails from "./FishDetails";
+import { useModal } from "../../hooks/useModal";
+
+const CollectionsModal = ({ isOpen, onClose }) => {
+  const { collections, isLoading, fetchCollections } = useCollections();
+  const [selectedFish, setSelectedFish] = useState(null);
+  const [isFishDetailsOpen, setIsFishDetailsOpen] = useState(false);
+  const { isAnimating, shouldRender } = useModal(isOpen);
+  const [imageErrors, setImageErrors] = useState({});
+
+  useEffect(() => {
+    if (isOpen) {
+      fetchCollections();
+    }
+  }, [isOpen, fetchCollections]);
+
+  const handleFishClick = (fish) => {
+    setSelectedFish(fish);
+    setIsFishDetailsOpen(true);
+  };
+
+  const handleImageError = (fishId) => {
+    setImageErrors((prev) => ({ ...prev, [fishId]: true }));
+  };
+
+  if (!shouldRender) return null;
+
+  return (
+    <div
+      className={`fixed inset-0 bg-black transition-opacity duration-300 ease-in-out ${
+        isAnimating ? "bg-opacity-50" : "bg-opacity-0"
+      } flex items-center justify-center z-50`}
+      onClick={onClose}
+    >
+      <div
+        className={`bg-white rounded-lg text-gray-800 relative w-full mx-4 sm:mx-8 md:mx-auto md:max-w-2xl max-h-[90vh] flex flex-col overflow-hidden transform transition-all duration-300 ease-in-out ${
+          isAnimating ? "scale-100 opacity-100" : "scale-95 opacity-0"
+        }`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="sticky top-0 bg-white z-10 p-4 sm:p-6 border-b border-gray-200">
+          <h2 className="text-xl sm:text-2xl font-bold text-gray-800 pr-8">
+            食べたオサカナ
+          </h2>
+          <button
+            onClick={onClose}
+            className="absolute top-2 right-2 sm:top-4 sm:right-4 text-gray-600 hover:bg-gray-100 rounded-full p-2 transition-colors duration-200"
+            aria-label="Close modal"
+          >
+            <X size={24} />
+          </button>
+        </div>
+
+        <div className="flex-grow overflow-y-auto p-4 sm:p-6">
+          {isLoading ? (
+            <div className="text-center py-4">読み込み中...</div>
+          ) : collections.length === 0 ? (
+            <div className="text-center py-4">
+              食べたオサカナはありません
+            </div>
+          ) : (
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+              {collections.map((fish) => (
+                <div
+                  key={fish.id}
+                  className="flex flex-col items-center p-2 cursor-pointer hover:bg-gray-50 rounded-lg"
+                  onClick={() => handleFishClick(fish)}
+                >
+                  {!imageErrors[fish.id] ? (
+                    <img
+                      src={fish.image_url}
+                      alt={fish.name}
+                      className="w-32 h-32 object-contain rounded-lg"
+                      onError={() => handleImageError(fish.id)}
+                    />
+                  ) : (
+                    <div className="w-32 h-32 bg-gray-200 flex items-center justify-center rounded-lg">
+                      <span className="text-sm text-gray-600">{fish.name}</span>
+                    </div>
+                  )}
+                  <p className="mt-2 text-center font-semibold">{fish.name}</p>
+                  {fish.fish_seasons?.[0] && (
+                    <SeasonTerm season={fish.fish_seasons[0]} />
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <FishDetails
+        isOpen={isFishDetailsOpen}
+        onClose={() => setIsFishDetailsOpen(false)}
+        fish={selectedFish}
+      />
+    </div>
+  );
+};
+
+CollectionsModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default CollectionsModal;

--- a/front/app/src/contexts/CollectionsContext.jsx
+++ b/front/app/src/contexts/CollectionsContext.jsx
@@ -1,0 +1,94 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+} from "react";
+import PropTypes from "prop-types";
+import { collectionsAPI } from "../api/collections";
+import { useAuth } from "./AuthContext";
+
+const CollectionsContext = createContext(null);
+
+export const CollectionsProvider = ({ children }) => {
+  const [collections, setCollections] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const { isAuthenticated } = useAuth();
+
+  const fetchCollections = useCallback(async () => {
+    if (!isAuthenticated()) return;
+    setIsLoading(true);
+    try {
+      const response = await collectionsAPI.getCollections();
+      setCollections(response);
+    } catch (error) {
+      console.error("Failed to fetch collections:", error);
+      setCollections([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [isAuthenticated]);
+
+  const addCollection = useCallback(
+    async (fishId) => {
+      try {
+        await collectionsAPI.addCollection(fishId);
+        await fetchCollections();
+      } catch (error) {
+        console.error("Failed to add collection:", error);
+        if (error.response?.status === 422) {
+          await fetchCollections();
+        }
+      }
+    },
+    [fetchCollections]
+  );
+
+  const removeCollection = useCallback(
+    async (fishId) => {
+      try {
+        await collectionsAPI.removeCollection(fishId);
+        await fetchCollections();
+      } catch (error) {
+        console.error("Failed to remove collection:", error);
+      }
+    },
+    [fetchCollections]
+  );
+
+  useEffect(() => {
+    const initializeCollections = async () => {
+      await fetchCollections();
+    };
+    initializeCollections();
+  }, [fetchCollections]);
+
+  const value = {
+    collections,
+    isLoading,
+    fetchCollections,
+    addCollection,
+    removeCollection,
+  };
+
+  return (
+    <CollectionsContext.Provider value={value}>
+      {children}
+    </CollectionsContext.Provider>
+  );
+};
+
+CollectionsProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export const useCollections = () => {
+  const context = useContext(CollectionsContext);
+  if (!context) {
+    throw new Error("useCollections must be used within a CollectionsProvider");
+  }
+  return context;
+};
+
+export default CollectionsContext;


### PR DESCRIPTION
# コレクション機能の基本実装

## 関連Issue
- [#236 コレクション機能の追加](https://github.com/Kuriyama301/osakana-calendar/issues/236)

## 変更内容

1. バックエンド実装
- マイグレーションファイル作成（fish_collections テーブル）
- FishCollection モデルの作成と関連付け
- コレクションコントローラーの実装
- ルーティングの設定

2. フロントエンド基盤実装
- CollectionsContext の作成
- collectionsAPI の実装（CRUD操作）
- CollectionButton コンポーネントの作成
- CollectionsModal の実装