### PR TITLE
Feature/#295 account management

### DIFF
--- a/api/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/api/app/controllers/api/v1/auth/registrations_controller.rb
@@ -4,6 +4,23 @@ module Api
       class RegistrationsController < Devise::RegistrationsController
         respond_to :json
         before_action :configure_sign_up_params, only: [:create]
+        before_action :authenticate_user!, only: [:destroy]
+
+        # アカウント削除のアクション
+        def destroy
+          if current_user&.destroy
+            render json: {
+              status: 'success',
+              message: 'アカウントが削除されました'
+            }, status: :ok
+          else
+            render json: {
+              status: 'error',
+              message: 'アカウントの削除に失敗しました',
+              errors: format_error_messages(current_user.errors)
+            }, status: :unprocessable_entity
+          end
+        end
 
         private
 

--- a/api/test/controllers/api/v1/auth/registrations_controller_test.rb
+++ b/api/test/controllers/api/v1/auth/registrations_controller_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class Api::V1::Auth::RegistrationsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
   test "should register new user" do
     assert_difference('User.count') do
       post api_v1_user_registration_path,
@@ -57,5 +59,39 @@ class Api::V1::Auth::RegistrationsControllerTest < ActionDispatch::IntegrationTe
     assert_response :unprocessable_entity
     json = JSON.parse(response.body)
     assert_equal 'error', json['status']
+  end
+
+  test "should delete user account when authenticated" do
+
+    user = User.create!(
+      email: 'delete-test@example.com',
+      password: 'password',
+      password_confirmation: 'password',
+      name: 'Delete Test User',
+      confirmed_at: Time.current
+    )
+
+    sign_in user
+    token = user.generate_jwt
+
+    assert_difference('User.count', -1) do
+      delete api_v1_user_registration_path,
+      headers: {
+        'Authorization': "Bearer #{token}",
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      },
+        as: :json
+    end
+
+    assert_response :ok
+  end
+
+  test "should not delete user account when not authenticated" do
+    assert_no_difference('User.count') do
+      delete api_v1_user_registration_path, as: :json
+    end
+
+    assert_response :unauthorized
   end
 end

--- a/front/app/src/App.jsx
+++ b/front/app/src/App.jsx
@@ -9,6 +9,8 @@ import { FavoritesProvider } from "./contexts/FavoritesContext";
 import EmailConfirmation from "./components/Auth/EmailConfirmation";
 import NewPasswordForm from "./components/Auth/NewPasswordForm";
 import { CollectionsProvider } from "./contexts/CollectionsContext";
+import { DeleteAccountProvider } from "./contexts/DeleteAccountContext";
+import DeleteAccountModal from "./components/Auth/DeleteAccountModal";
 
 class ErrorBoundary extends Component {
   constructor(props) {
@@ -79,28 +81,31 @@ function App() {
       <AuthProvider>
         <FavoritesProvider>
           <CollectionsProvider>
-            <CalendarProvider>
-              <Router>
-                <div className="h-screen overflow-hidden">
-                  <LoadingScreen isOpen={isInitialLoading} />
-                  <Suspense fallback={<LoadingScreen isOpen={true} />}>
-                    <main className="h-full">
-                      <Routes>
-                        <Route path="/" element={<HomePage />} />
-                        <Route
-                          path="/auth/confirm"
-                          element={<EmailConfirmation />}
-                        />
-                        <Route
-                          path="/reset-password"
-                          element={<NewPasswordForm />}
-                        />
-                      </Routes>
-                    </main>
-                  </Suspense>
-                </div>
-              </Router>
-            </CalendarProvider>
+            <Router>
+              <DeleteAccountProvider>
+                <CalendarProvider>
+                  <div className="h-screen overflow-hidden">
+                    <LoadingScreen isOpen={isInitialLoading} />
+                    <Suspense fallback={<LoadingScreen isOpen={true} />}>
+                      <main className="h-full">
+                        <Routes>
+                          <Route path="/" element={<HomePage />} />
+                          <Route
+                            path="/auth/confirm"
+                            element={<EmailConfirmation />}
+                          />
+                          <Route
+                            path="/reset-password"
+                            element={<NewPasswordForm />}
+                          />
+                        </Routes>
+                        <DeleteAccountModal />
+                      </main>
+                    </Suspense>
+                  </div>
+                </CalendarProvider>
+              </DeleteAccountProvider>
+            </Router>
           </CollectionsProvider>
         </FavoritesProvider>
       </AuthProvider>

--- a/front/app/src/components/Auth/DeleteAccountModal.jsx
+++ b/front/app/src/components/Auth/DeleteAccountModal.jsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { X } from "lucide-react";
+import { useModal } from "../../hooks/useModal";
+import { useDeleteAccount } from "../../contexts/DeleteAccountContext";
+
+const DeleteAccountModal = () => {
+  const { isModalOpen, isDeleting, error, closeModal, deleteAccount } =
+    useDeleteAccount();
+  const { isAnimating, shouldRender } = useModal(isModalOpen);
+
+  if (!shouldRender) return null;
+
+  return (
+    <div
+      className={`fixed inset-0 bg-black transition-opacity duration-300 ${
+        isAnimating ? "bg-opacity-50" : "bg-opacity-0"
+      } flex items-center justify-center z-50`}
+      onClick={closeModal}
+    >
+      <div
+        className={`bg-white rounded-lg text-gray-800 relative w-full mx-4 sm:mx-8 md:mx-auto md:max-w-md transform transition-all duration-300 ${
+          isAnimating ? "scale-100 opacity-100" : "scale-95 opacity-0"
+        }`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="p-6">
+          <button
+            onClick={closeModal}
+            className="absolute top-2 right-2 text-gray-600 bg-white hover:bg-gray-300 hover:text-gray-800 rounded-full p-2 transition-colors duration-200"
+            aria-label="Close modal"
+          >
+            <X size={24} />
+          </button>
+
+          <h2 className="text-xl font-bold mb-4">アカウントの削除</h2>
+
+          <div className="space-y-4">
+            <div className="text-gray-600">
+              <p className="mb-4">
+                アカウントを削除すると、以下のデータがすべて削除されます：
+              </p>
+              <ul className="list-disc pl-5 mb-4 space-y-2">
+                <li>お気に入りの魚のデータ</li>
+                <li>コレクションデータ</li>
+                <li>その他のすべてのデータ</li>
+              </ul>
+              <p className="font-medium text-red-600">
+                この操作は取り消すことができません。本当に削除しますか？
+              </p>
+            </div>
+
+            {error && (
+              <div className="p-3 bg-red-100 text-red-700 rounded">{error}</div>
+            )}
+
+            <div className="flex justify-end space-x-4 pt-4">
+              <button
+                onClick={closeModal}
+                disabled={isDeleting}
+                className="px-4 py-2 text-gray-600 hover:bg-gray-100 rounded"
+              >
+                キャンセル
+              </button>
+              <button
+                onClick={deleteAccount}
+                disabled={isDeleting}
+                className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 disabled:opacity-50"
+              >
+                {isDeleting ? "削除中..." : "アカウントを削除する"}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DeleteAccountModal;

--- a/front/app/src/components/Common/HelpModal.jsx
+++ b/front/app/src/components/Common/HelpModal.jsx
@@ -2,10 +2,12 @@ import React, { useState } from "react";
 import { useModal } from "../../hooks/useModal";
 import { X, Info, Lock, Mail, Book } from "lucide-react";
 import PropTypes from "prop-types";
+import { useDeleteAccount } from "../../contexts/DeleteAccountContext";
 
 const HelpModal = ({ isOpen, onClose }) => {
   const { isAnimating, shouldRender } = useModal(isOpen);
   const [selectedSection, setSelectedSection] = useState("terms");
+  const { openModal: openDeleteModal } = useDeleteAccount();
 
   if (!shouldRender) return null;
 
@@ -129,7 +131,21 @@ const HelpModal = ({ isOpen, onClose }) => {
           {"\n"}- 返信用のメールアドレスを正確にご記入ください{"\n\n"}
           4. 注意事項{"\n"}- 返信は平日のみとなります{"\n"}-
           内容によっては回答を差し控えさせていただく場合があります{"\n"}-
-          お問い合わせ内容は今後のサービス改善に活用させていただく場合があります
+          お問い合わせ内容は今後のサービス改善に活用させていただく場合があります{"\n\n"}
+          5. アカウントの削除{"\n"}- 
+          アカウントを削除する場合は
+          <button
+            onClick={(e) => {
+              e.preventDefault();
+              onClose();
+              openDeleteModal();
+            }}
+            className="text-blue-600 hover:text-blue-800 underline mx-1"
+          >
+            こちら
+          </button>
+          から手続きを行ってください。
+          削除後は全てのデータが完全に削除され、復元することはできません。
         </>
       ),
     },

--- a/front/app/src/contexts/DeleteAccountContext.jsx
+++ b/front/app/src/contexts/DeleteAccountContext.jsx
@@ -12,7 +12,7 @@ export const DeleteAccountProvider = ({ children }) => {
   const [isDeleting, setIsDeleting] = useState(false);
   const [error, setError] = useState('');
   const navigate = useNavigate();
-  const { logout, isAuthenticated } = useAuth();
+  const { isAuthenticated } = useAuth();
 
   const openModal = useCallback(() => {
     setIsModalOpen(true);

--- a/front/app/src/contexts/DeleteAccountContext.jsx
+++ b/front/app/src/contexts/DeleteAccountContext.jsx
@@ -1,0 +1,88 @@
+import { createContext, useContext, useState, useCallback } from 'react';
+import PropTypes from 'prop-types';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from './AuthContext';
+import client from '../api/client';
+import { tokenManager } from '../utils/tokenManager';
+
+const DeleteAccountContext = createContext(null);
+
+export const DeleteAccountProvider = ({ children }) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [error, setError] = useState('');
+  const navigate = useNavigate();
+  const { logout, isAuthenticated } = useAuth();
+
+  const openModal = useCallback(() => {
+    setIsModalOpen(true);
+    setError('');
+  }, []);
+
+  const closeModal = useCallback(() => {
+    setIsModalOpen(false);
+    setError('');
+  }, []);
+
+  const deleteAccount = useCallback(async () => {
+    if (!isAuthenticated()) {
+      setError('ログインしてください。');
+      setIsDeleting(false);
+      return;
+    }
+
+    try {
+      setIsDeleting(true);
+      setError('');
+      
+      const response = await client.delete('/api/v1/auth');
+      
+      if (response.data.status === 'success') {
+        // トークンとユーザー情報をクリア
+        tokenManager.clearAll();
+        // ホームページにリダイレクト
+        navigate('/', { replace: true });
+        // モーダルを閉じる
+        closeModal();
+      }
+    } catch (err) {
+      console.error('Delete account error:', err);
+      if (err.response?.status === 401) {
+        setError('ログインしてください。');
+      } else {
+        setError(err.message || 'アカウントの削除に失敗しました');
+      }
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [navigate, isAuthenticated, closeModal]);
+
+  const value = {
+    isModalOpen,
+    isDeleting,
+    error,
+    openModal,
+    closeModal,
+    deleteAccount
+  };
+
+  return (
+    <DeleteAccountContext.Provider value={value}>
+      {children}
+    </DeleteAccountContext.Provider>
+  );
+};
+
+DeleteAccountProvider.propTypes = {
+  children: PropTypes.node.isRequired
+};
+
+export const useDeleteAccount = () => {
+  const context = useContext(DeleteAccountContext);
+  if (!context) {
+    throw new Error('useDeleteAccount must be used within a DeleteAccountProvider');
+  }
+  return context;
+};
+
+export default DeleteAccountContext;


### PR DESCRIPTION
# アカウント削除機能の実装

## 関連Issue
- [#295 アカウント管理機能の追加](https://github.com/Kuriyama301/osakana-calendar/issues/295)

## 変更内容

1. バックエンド実装
- registrations_controllerにアカウント削除アクションを追加
- 関連する単体テストの追加
- ユーザー関連データ（お気に入り、コレクション）の削除処理実装

2. フロントエンド実装
- DeleteAccountContext の作成
  - 削除処理の状態管理
  - エラーハンドリング
  - 認証状態との連携
- DeleteAccountModal の実装
  - 削除確認UI
  - エラーメッセージの表示
- HelpModal の拡張
  - アカウント削除へのアクセスポイント追加
  - 未ログイン時の適切なガイダンス表示